### PR TITLE
minor: added templates in the examples section of docs

### DIFF
--- a/docs/guides/examples/templates.mdx
+++ b/docs/guides/examples/templates.mdx
@@ -1,0 +1,13 @@
+---
+title: 'Templates'
+description: 'Find a list of curated templates to help get you started'
+---
+
+## Introduction
+
+Here's a list of curated templates for Latitude projects that showcase some typical use cases. More will be added in the future.
+
+Here's the list:
+
+- [Netflix template](https://github.com/latitude-dev/sample-netflix) - Contains some data, queries and a fairly complex view to showcase the main features of Latitude
+- [Flyio template](https://github.com/latitude-dev/sample-netflix-flyio) - Contains configuration and documentation on how to deploy a Latitude production build to Fly.io

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -70,7 +70,11 @@
     },
     {
       "group": "Examples",
-      "pages": ["guides/examples/basic-example", "guides/examples/api"]
+      "pages": [
+        "guides/examples/basic-example",
+        "guides/examples/api",
+        "guides/examples/templates"
+      ]
     },
     {
       "group": "Deploy",


### PR DESCRIPTION
# WHAT
Adds links to templates in the examples section to help people get started with more complex projects or particular uses cases.