### PR TITLE
feature: add automatic releases from CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,12 @@ jobs:
           version: 8
           run_install: true
 
-      - name: Create Release Pull Request
+      - name: Create Release Pull Request or Publish to npm
+        id: changesets
         uses: changesets/action@v1
+        with:
+          # This expects us to have a script called release which does a build for our packages and calls changeset publish
+          publish: pnpm release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "prettier": "turbo prettier",
     "build": "turbo build",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
+    "release": "pnpm run build && pnpm run changeset publish",
     "publish-packages": "turbo run build lint tc test && pnpm run changeset version && pnpm run changeset publish",
     "latitude-dev": "./node_modules/.bin/latitude"
   },


### PR DESCRIPTION
# WHAT
Adds necessary configuration for automatic releases using changesets github action. This action will also automatically create the github release tags upon publishing. Here are their [docs](https://github.com/changesets/action?tab=readme-ov-file#inputs).