### PR TITLE
minor: remove peer dependencies between latitude packages

### DIFF
--- a/.changeset/silent-kiwis-sniff.md
+++ b/.changeset/silent-kiwis-sniff.md
@@ -1,0 +1,15 @@
+---
+"@latitude-data/databricks-connector": patch
+"@latitude-data/postgresql-connector": patch
+"@latitude-data/snowflake-connector": patch
+"@latitude-data/bigquery-connector": patch
+"@latitude-data/athena-connector": patch
+"@latitude-data/duckdb-connector": patch
+"@latitude-data/sqlite-connector": patch
+"@latitude-data/mssql-connector": patch
+"@latitude-data/mysql-connector": patch
+"@latitude-data/trino-connector": patch
+"@latitude-data/base-connector": patch
+---
+
+Moved latitude packages from peer to regular dependencies

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -3,18 +3,8 @@ name: Linter & Types
 on:
   push:
     branches: ['main']
-    paths:
-      - 'apps/server/src/**/*.ts'
-      - 'apps/server/src/**/*.svelte'
-      - 'packages/client/svelte/src/*.svelte'
-      - 'packages/**/*.ts'
-
   pull_request:
-    paths:
-      - 'apps/server/src/**/*.ts'
-      - 'apps/server/src/**/*.svelte'
-      - 'packages/client/svelte/src/*.svelte'
-      - 'packages/**/*.ts'
+    branches: ['main']
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,18 +3,8 @@ name: Tests suite
 on:
   push:
     branches: ['main']
-    paths:
-      - 'apps/server/src/**/*.ts'
-      - 'apps/server/src/**/*.svelte'
-      - 'packages/client/svelte/src/*.svelte'
-      - 'packages/**/*.ts'
-
   pull_request:
-    paths:
-      - 'apps/server/src/**/*.svelte'
-      - 'apps/server/src/**/*.ts'
-      - 'packages/**/*.ts'
-      - 'packages/client/svelte/src/*.svelte'
+    branches: ['main']
 
 jobs:
   test:

--- a/packages/connectors/athena/package.json
+++ b/packages/connectors/athena/package.json
@@ -12,10 +12,6 @@
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "peerDependencies": {
-    "@latitude-data/base-connector": "workspace:^",
-    "@latitude-data/query_result": "workspace:^"
-  },
   "devDependencies": {
     "@latitude-data/eslint-config": "workspace:*",
     "@latitude-data/typescript": "workspace:*",
@@ -25,6 +21,8 @@
     "rollup": "^4.10.0"
   },
   "dependencies": {
+    "@latitude-data/base-connector": "workspace:^",
+    "@latitude-data/query_result": "workspace:^",
     "@aws-sdk/client-athena": "^3.515.0"
   }
 }

--- a/packages/connectors/base/package.json
+++ b/packages/connectors/base/package.json
@@ -24,9 +24,7 @@
     "vitest": "^1.2.2"
   },
   "dependencies": {
-    "@latitude-data/sql-compiler": "workspace:*"
-  },
-  "peerDependencies": {
+    "@latitude-data/sql-compiler": "workspace:*",
     "@latitude-data/query_result": "workspace:*"
   },
   "main": "dist/index.js",

--- a/packages/connectors/bigquery/package.json
+++ b/packages/connectors/bigquery/package.json
@@ -14,10 +14,6 @@
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "peerDependencies": {
-    "@latitude-data/base-connector": "workspace:^",
-    "@latitude-data/query_result": "workspace:^"
-  },
   "devDependencies": {
     "@latitude-data/eslint-config": "workspace:*",
     "@latitude-data/typescript": "workspace:*",
@@ -26,6 +22,8 @@
     "rollup": "^4.10.0"
   },
   "dependencies": {
+    "@latitude-data/base-connector": "workspace:^",
+    "@latitude-data/query_result": "workspace:^",
     "@google-cloud/bigquery": "^7.4.0",
     "google-auth-library": "^9.6.3"
   }

--- a/packages/connectors/databricks/package.json
+++ b/packages/connectors/databricks/package.json
@@ -23,11 +23,9 @@
     "tslib": "^2.4.1",
     "typescript": "^5.2.2"
   },
-  "peerDependencies": {
-    "@latitude-data/base-connector": "workspace:*",
-    "@latitude-data/query_result": "workspace:*"
-  },
   "dependencies": {
+    "@latitude-data/base-connector": "workspace:*",
+    "@latitude-data/query_result": "workspace:*",
     "@databricks/sql": "^1.8.1"
   },
   "main": "dist/index.js",

--- a/packages/connectors/duckdb/package.json
+++ b/packages/connectors/duckdb/package.json
@@ -14,10 +14,6 @@
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "peerDependencies": {
-    "@latitude-data/base-connector": "workspace:^",
-    "@latitude-data/query_result": "workspace:^"
-  },
   "devDependencies": {
     "@latitude-data/eslint-config": "workspace:*",
     "@latitude-data/typescript": "workspace:*",
@@ -26,6 +22,8 @@
     "rollup": "^4.10.0"
   },
   "dependencies": {
+    "@latitude-data/base-connector": "workspace:^",
+    "@latitude-data/query_result": "workspace:^",
     "duckdb-async": "^0.9.2"
   }
 }

--- a/packages/connectors/mssql/package.json
+++ b/packages/connectors/mssql/package.json
@@ -14,10 +14,6 @@
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "peerDependencies": {
-    "@latitude-data/base-connector": "workspace:^",
-    "@latitude-data/query_result": "workspace:^"
-  },
   "devDependencies": {
     "@latitude-data/eslint-config": "workspace:*",
     "@latitude-data/typescript": "workspace:*",
@@ -27,6 +23,8 @@
     "rollup": "^4.10.0"
   },
   "dependencies": {
+    "@latitude-data/base-connector": "workspace:^",
+    "@latitude-data/query_result": "workspace:^",
     "mssql": "^10.0.2"
   }
 }

--- a/packages/connectors/mysql/package.json
+++ b/packages/connectors/mysql/package.json
@@ -14,10 +14,6 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "peerDependencies": {
-    "@latitude-data/base-connector": "workspace:^",
-    "@latitude-data/query_result": "workspace:^"
-  },
   "devDependencies": {
     "@latitude-data/eslint-config": "workspace:*",
     "@latitude-data/typescript": "workspace:*",
@@ -28,6 +24,8 @@
     "rollup": "^4.10.0"
   },
   "dependencies": {
+    "@latitude-data/base-connector": "workspace:^",
+    "@latitude-data/query_result": "workspace:^",
     "mysql": "^2.18.1"
   }
 }

--- a/packages/connectors/postgresql/package.json
+++ b/packages/connectors/postgresql/package.json
@@ -28,11 +28,9 @@
     "vite-tsconfig-paths": "^4.3.1",
     "vitest": "^1.3.1"
   },
-  "peerDependencies": {
-    "@latitude-data/base-connector": "workspace:*",
-    "@latitude-data/query_result": "workspace:*"
-  },
   "dependencies": {
+    "@latitude-data/base-connector": "workspace:*",
+    "@latitude-data/query_result": "workspace:*",
     "pg": "^8.11.3"
   }
 }

--- a/packages/connectors/snowflake/package.json
+++ b/packages/connectors/snowflake/package.json
@@ -12,10 +12,6 @@
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "peerDependencies": {
-    "@latitude-data/base-connector": "workspace:^",
-    "@latitude-data/query_result": "workspace:^"
-  },
   "devDependencies": {
     "@latitude-data/eslint-config": "workspace:*",
     "@latitude-data/typescript": "workspace:*",
@@ -24,6 +20,8 @@
     "rollup": "^4.10.0"
   },
   "dependencies": {
+    "@latitude-data/base-connector": "workspace:^",
+    "@latitude-data/query_result": "workspace:^",
     "@types/snowflake-sdk": "^1.6.20",
     "snowflake-sdk": "^1.9.3"
   }

--- a/packages/connectors/sqlite/package.json
+++ b/packages/connectors/sqlite/package.json
@@ -16,10 +16,6 @@
   "types": "dist/index.d.ts",
   "keywords": [],
   "author": "",
-  "peerDependencies": {
-    "@latitude-data/base-connector": "workspace:^",
-    "@latitude-data/query_result": "workspace:^"
-  },
   "devDependencies": {
     "@latitude-data/eslint-config": "workspace:*",
     "@latitude-data/typescript": "workspace:*",
@@ -28,6 +24,8 @@
     "rollup": "^4.10.0"
   },
   "dependencies": {
+    "@latitude-data/base-connector": "workspace:^",
+    "@latitude-data/query_result": "workspace:^",
     "sqlite3": "^5.1.7"
   }
 }

--- a/packages/connectors/trino/package.json
+++ b/packages/connectors/trino/package.json
@@ -24,11 +24,9 @@
     "typescript": "^5.2.2",
     "tslib": "^2.4.1"
   },
-  "peerDependencies": {
-    "@latitude-data/base-connector": "workspace:*",
-    "@latitude-data/query_result": "workspace:*"
-  },
   "dependencies": {
+    "@latitude-data/base-connector": "workspace:*",
+    "@latitude-data/query_result": "workspace:*",
     "trino-client": "^0.2.2"
   }
 }


### PR DESCRIPTION
# WHAT
There's really no point in having peer dependencies between latitude packages. Let's remove them.