### PR TITLE
minor: ignore cli spawn process warnings

### DIFF
--- a/.changeset/four-carpets-fly.md
+++ b/.changeset/four-carpets-fly.md
@@ -1,0 +1,5 @@
+---
+"@latitude-data/cli": patch
+---
+
+Ignore CLI spawn process warnings

--- a/packages/cli/src/commands/dev/runDev.ts
+++ b/packages/cli/src/commands/dev/runDev.ts
@@ -122,6 +122,8 @@ const onStdout =
   }
 
 const onStderr = (data: Buffer) => {
+  if (data.includes('WARNING')) return
+
   console.log(colors.yellow(data.toString()))
 }
 


### PR DESCRIPTION
They are harmless and only increase noise