### PR TITLE
Fix: queries not refetching

### DIFF
--- a/.changeset/hungry-toes-care.md
+++ b/.changeset/hungry-toes-care.md
@@ -1,0 +1,6 @@
+---
+"@latitude-data/client": patch
+"@latitude-data/server": patch
+---
+
+Fix RunButton didn't refetch all queries when no queries were specified, and the force tag was not included in forced requests.

--- a/apps/server/src/lib/autoimports/RunButton/index.svelte
+++ b/apps/server/src/lib/autoimports/RunButton/index.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { Button } from "@latitude-data/svelte"
-  import { computeQuery } from "$lib/stores/queries"
+  import { computeQueries } from "$lib/stores/queries"
   import { createEventDispatcher } from "svelte"
 
   export let query: string | undefined = undefined
@@ -10,7 +10,7 @@
 
   const handleClick = () => {
     const queriesToRun = query ? [query] : queries
-    computeQuery(queriesToRun)
+    computeQueries({ queryPaths: queriesToRun })
     
     dispatch("click")
   }

--- a/apps/server/src/routes/api/queries/[...query]/+server.ts
+++ b/apps/server/src/routes/api/queries/[...query]/+server.ts
@@ -1,8 +1,7 @@
 import handleError from '$lib/errors/handler'
 import findOrCompute from '$lib/query_service/find_or_compute'
 import { RichDate, parse } from '@latitude-data/custom_types'
-
-const FORCE_PARAM = '__force'
+import { FORCE_REFETCH_PARAMETER } from '@latitude-data/client'
 
 export async function GET({
   params,
@@ -32,12 +31,12 @@ function getQueryParams(url: URL) {
   const searchParams = url.searchParams
   const params: { [key: string]: IValue } = {}
   for (const [key, value] of searchParams) {
-    if (key !== FORCE_PARAM) {
+    if (key !== FORCE_REFETCH_PARAMETER) {
       params[key] = castValue(value)
     }
   }
 
-  return { params, force: searchParams.get(FORCE_PARAM) === 'true' }
+  return { params, force: searchParams.get(FORCE_REFETCH_PARAMETER) === 'true' }
 }
 
 function castValue(value: string): IValue {

--- a/apps/server/src/routes/api/queries/[...query]/server.test.ts
+++ b/apps/server/src/routes/api/queries/[...query]/server.test.ts
@@ -48,8 +48,8 @@ describe('GET endpoint', () => {
         resolve({
           compiledQuery: 'SELECT * FROM winterfell',
           resolvedParams: [],
-        })
-      )
+        }),
+      ),
     )
   })
 
@@ -74,7 +74,7 @@ describe('GET endpoint', () => {
   it('should return the cached query if available', async () => {
     const queryResult = { toJSON: () => JSON.stringify(payload) }
     vi.spyOn(cache, 'find').mockReturnValueOnce(
-      queryResult as unknown as QueryResult
+      queryResult as unknown as QueryResult,
     )
     const response = await GET({
       params: { query: 'testQuery' },
@@ -96,7 +96,7 @@ describe('GET endpoint', () => {
     })
     mockRunQuery.mockResolvedValueOnce(queryResult)
     vi.spyOn(cache, 'find').mockReturnValueOnce(
-      queryResult as unknown as QueryResult
+      queryResult as unknown as QueryResult,
     )
     const response = await GET({
       params: { query: 'testQuery' },
@@ -123,7 +123,7 @@ describe('GET endpoint', () => {
   it('should return 404 status if the query file is not found', async () => {
     const findQueryFileMock = findQueryFile as Mock
     findQueryFileMock.mockRejectedValue(
-      new QueryNotFoundError('Query file not found')
+      new QueryNotFoundError('Query file not found'),
     )
     const response = await GET({
       params: { query: 'testQuery' },
@@ -146,5 +146,4 @@ describe('GET endpoint', () => {
     expect(response.status).toBe(500)
     expect(await response.text()).toBe('There was an error in this query')
   })
-
 })

--- a/packages/client/core/src/stores/queries.ts
+++ b/packages/client/core/src/stores/queries.ts
@@ -4,6 +4,8 @@ import QueryResult, {
   type QueryResultPayload,
 } from '@latitude-data/query_result'
 
+export const FORCE_REFETCH_PARAMETER = '__force'
+
 type QueryRequest = {
   queryPath: string
   params?: Record<string, unknown>
@@ -94,10 +96,9 @@ export const store = createStore<StoreState>((set, get) => {
     forceRefetch: async ({ queryPath, params }) => {
       const queryKey = createQueryKey(queryPath, params || {})
       performQueryFetch(queryKey, async () => {
-        // TODO: Add force parameter or header when backend cache is implemented
         const response = await api.get<QueryResultPayload>(
           `api/queries/${queryPath}`,
-          params
+          { ...params, [FORCE_REFETCH_PARAMETER]: 'true' }
         )
 
         return new QueryResult(response)


### PR DESCRIPTION
Solved problems:
 - RunButton didn't call any refetch if no queries were specified
 - All initial fetches were using `force: true`
 - The force tag wasn't being added to force requests

Also changed the method of sending the force tag from a `__force` parameter to a `X-Force-Refetch` header.