### PR TITLE
fix: incorrect result parsing in snowflake connector

### DIFF
--- a/.changeset/wet-cups-whisper.md
+++ b/.changeset/wet-cups-whisper.md
@@ -1,0 +1,5 @@
+---
+"@latitude-data/snowflake-connector": patch
+---
+
+fixes a bug that caused most results from snowflake to not get correctly parsed

--- a/packages/connectors/snowflake/src/index.ts
+++ b/packages/connectors/snowflake/src/index.ts
@@ -67,7 +67,7 @@ export class SnowflakeConnector extends BaseConnector {
             })
 
             stream.on('data', (row) => {
-              result.rows.push(row)
+              result.rows.push(Object.values(row))
             })
 
             stream.on('end', () => {


### PR DESCRIPTION
# WHAT

Fixes a bug that caused snowflake results to not get correctly parsed in most queries.