### PR TITLE
fix: latest version fix

### DIFF
--- a/.changeset/wild-planets-thank.md
+++ b/.changeset/wild-planets-thank.md
@@ -1,0 +1,5 @@
+---
+"@latitude-data/cli": patch
+---
+
+fix: do not hard crash when npm view process outputs to stderr

--- a/packages/cli/src/commands/update/index.ts
+++ b/packages/cli/src/commands/update/index.ts
@@ -4,9 +4,8 @@ import setupApp from '$src/lib/setupApp'
 import { cleanTerminal, onError } from '$src/utils'
 import { DEFAULT_VERSION_LIST } from '../constants'
 import { CLIConfig } from '$src/config'
-import {
+import getLatitudeVersions, {
   getInstalledVersion,
-  getLatitudeVersions,
 } from '$src/lib/getAppVersions'
 import telemetry from '$src/lib/telemetry'
 

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -2,10 +2,10 @@ import { exec } from 'child_process'
 import mri from 'mri'
 import { APP_FOLDER, LATITUDE_CONFIG_FILE } from './commands/constants'
 import path from 'path'
-import { findConfigFile } from './lib/latitudeConfig/findOrCreate'
 import validateFn from './lib/latitudeConfig/validate'
+import findConfigFile from './lib/latitudeConfig/findConfigFile'
 
-enum PackageManager {
+export enum PackageManager {
   pnpm = 'pnpm',
   npm = 'npm',
 }
@@ -82,7 +82,7 @@ export class CLIConfig {
   }
   private _latitudeConfig: PartialLatitudeConfig | null = null
 
-  constructor({ source, dev }: { source: string, dev: boolean }) {
+  constructor({ source, dev }: { source: string; dev: boolean }) {
     this.dev = dev
     this.pro = !this.dev
     this.source = source

--- a/packages/cli/src/lib/getAppVersions.test.ts
+++ b/packages/cli/src/lib/getAppVersions.test.ts
@@ -1,0 +1,50 @@
+import { exec } from 'child_process'
+import getLatitudeVersions from './getAppVersions'
+import { PackageManager, PackageManagerWithFlags } from '$src/config'
+import { vi, describe, it, expect } from 'vitest'
+
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal() as unknown as Object
+
+  return {
+    ...actual,
+    exec: vi.fn((_, callback) => {
+      callback(null, JSON.stringify(['1.1.1']), null)
+    }),
+  }
+})
+
+describe('getAppVersions', () => {
+  const pkgManager: PackageManagerWithFlags = {
+    command: PackageManager.npm,
+    flags: {
+      mandatoryInstallFlags: [],
+      installFlags: { silent: '--silent' },
+    },
+  }
+
+  it('should return a list of semver versions', async () => {
+    const results = await getLatitudeVersions({ pkgManager })
+
+    expect(results).toBeInstanceOf(Array)
+    expect(results.length).toBeGreaterThan(0)
+  })
+
+  it('should throw if the node exec command fails with an error', () => {
+    // @ts-expect-error mock
+    exec.mockImplementation((_, callback) => {
+      callback(new Error('Error'), null, null)
+    })
+
+    expect(getLatitudeVersions({ pkgManager })).rejects.toThrow('Error')
+  })
+
+  it('should not throw if the node exec command outputs to stderr but contains no Error', () => {
+    // @ts-expect-error mock
+    exec.mockImplementation((_, callback) => {
+      callback(null, null, 'Error')
+    })
+
+    expect(getLatitudeVersions({ pkgManager })).resolves.toBeDefined()
+  })
+})

--- a/packages/cli/src/lib/getAppVersions.ts
+++ b/packages/cli/src/lib/getAppVersions.ts
@@ -7,19 +7,24 @@ import {
   PACKAGE_NAME,
 } from '../commands/constants'
 import { type PackageManagerWithFlags } from '../config'
+import chalk from 'chalk'
 
 export function getInstalledVersion(appDir: string) {
   let version = null
   try {
-    const packageJson = readFileSync(`${appDir}/${APP_FOLDER}/package.json`, 'utf-8')
-     version = JSON.parse(packageJson).version
+    const packageJson = readFileSync(
+      `${appDir}/${APP_FOLDER}/package.json`,
+      'utf-8',
+    )
+    version = JSON.parse(packageJson).version
   } catch (e) {
     // Do nothing
   }
+
   return version
 }
 
-export async function getLatitudeVersions({
+export default async function getLatitudeVersions({
   pkgManager,
   onFetch,
 }: {
@@ -27,16 +32,14 @@ export async function getLatitudeVersions({
   onFetch?: () => void
 }) {
   const command = `${pkgManager.command} view ${PACKAGE_NAME} versions --json`
+
   return new Promise<string[]>((resolve, reject) => {
     exec(command, (error, stdout, stderr) => {
       onFetch?.()
 
-      if (error) {
-        reject(error)
-      }
-
+      if (error) reject(error)
       if (stderr) {
-        reject(stderr)
+        console.log(chalk.yellow(stderr))
       }
 
       let versions: string[] | undefined = undefined

--- a/packages/cli/src/lib/latitudeConfig/findConfigFile.ts
+++ b/packages/cli/src/lib/latitudeConfig/findConfigFile.ts
@@ -1,0 +1,28 @@
+import { LATITUDE_CONFIG_FILE } from '$src/commands/constants'
+import fsExtra from 'fs-extra'
+
+export type ConfigData = {
+  version?: string
+  name: string
+}
+
+export type ConfigFile = {
+  data: ConfigData
+  path: string
+}
+
+export default function findConfigFile({
+  appDir,
+  throws,
+}: {
+  appDir: string
+  throws: boolean
+}): ConfigFile {
+  const configPath = `${appDir}/${LATITUDE_CONFIG_FILE}`
+  const data = fsExtra.readJsonSync(configPath, { throws }) as ConfigData
+
+  return {
+    path: configPath,
+    data,
+  }
+}

--- a/packages/cli/src/lib/latitudeConfig/findOrCreate.test.ts
+++ b/packages/cli/src/lib/latitudeConfig/findOrCreate.test.ts
@@ -1,0 +1,104 @@
+import getLatestVersion from './getLatestVersion'
+import findConfigFile from './findConfigFile'
+import findOrCreateConfigFile from './findOrCreate' // Adjust with the correct path
+import validate from './validate'
+import { PackageManager, PackageManagerWithFlags } from '$src/config'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import fsExtra from 'fs-extra'
+
+// Mock the fsExtra module
+vi.mock('fs-extra', () => {
+  return {
+    default: {
+      readJsonSync: vi.fn(),
+      writeJsonSync: vi.fn(),
+    },
+  }
+})
+
+vi.mock('./findConfigFile')
+vi.mock('./getLatestVersion')
+vi.mock('../getAppVersions', () => ({
+  getLatestVersions: vi.fn(),
+}))
+
+vi.mock('./validate')
+
+describe('findOrCreateConfigFile', () => {
+  const appDir = '/test/app'
+  const pkgManager: PackageManagerWithFlags = {
+    command: PackageManager.npm,
+    flags: {
+      mandatoryInstallFlags: [],
+      installFlags: { silent: '--silent' },
+    },
+  }
+  const configPath = `${appDir}/config.json`
+
+  beforeEach(() => {
+    // Reset mocks before each test
+    vi.resetAllMocks()
+    // Setup default mock implementations here if applicable
+  })
+
+  it('should use existing version from config file when present', async () => {
+    // @ts-expect-error mock
+    findConfigFile.mockImplementation(() => ({
+      path: configPath,
+      data: { version: '1.0.0', name: 'test-app' },
+    }))
+    // @ts-expect-error mock
+    validate.mockReturnValue({ valid: true })
+
+    const result = await findOrCreateConfigFile({ appDir, pkgManager })
+
+    expect(result).toBeTruthy()
+    expect(fsExtra.writeJsonSync).toHaveBeenCalledWith(
+      configPath,
+      expect.objectContaining({ version: '1.0.0' }),
+      { spaces: 2 },
+    )
+  })
+
+  it('should fetch the latest version when version is not present in config file', async () => {
+    // @ts-expect-error mock
+    findConfigFile.mockImplementation(() => ({
+      path: configPath,
+      data: { name: 'test-app' },
+    }))
+
+    // @ts-expect-error mock
+    getLatestVersion.mockResolvedValue('1.2.3')
+    // @ts-expect-error mock
+    validate.mockReturnValue({ valid: true })
+
+    const result = await findOrCreateConfigFile({ appDir, pkgManager })
+
+    expect(getLatestVersion).toHaveBeenCalledWith(pkgManager)
+    expect(result).toBeTruthy()
+    expect(fsExtra.writeJsonSync).toHaveBeenCalledWith(
+      configPath,
+      expect.objectContaining({ version: '1.2.3' }),
+      { spaces: 2 },
+    )
+  })
+
+  it('should process.exit with code 1 when version is not present in config file and getLatestVersion fails', async () => {
+    // @ts-expect-error mock
+    findConfigFile.mockImplementation(() => ({
+      path: configPath,
+      data: { name: 'test-app' },
+    }))
+
+    // @ts-expect-error mock
+    getLatestVersion.mockRejectedValue(
+      new Error('Failed to fetch latest version'),
+    )
+
+    const spy = vi.spyOn(process, 'exit').mockImplementation(vi.fn())
+
+    await findOrCreateConfigFile({ appDir, pkgManager })
+
+    expect(spy).toHaveBeenCalledWith(1)
+  })
+})

--- a/packages/cli/src/lib/latitudeConfig/getLatestVersion.ts
+++ b/packages/cli/src/lib/latitudeConfig/getLatestVersion.ts
@@ -1,0 +1,29 @@
+import { PackageManagerWithFlags } from '$src/config'
+import { onError } from '$src/utils'
+import getLatitudeVersions from '../getAppVersions'
+
+export default async function getLatestVersion(
+  pkgManager: PackageManagerWithFlags,
+) {
+  try {
+    const versions = await getLatitudeVersions({ pkgManager })
+    const latestVersion = versions[0]
+    if (!latestVersion) {
+      onError({
+        message:
+          'No Latitude versions found. If the issue persits, please report it.',
+      })
+
+      process.exit(1)
+    }
+
+    return latestVersion
+  } catch (error) {
+    onError({
+      message: 'Error getting Latitude versions',
+      error: error as Error,
+    })
+
+    process.exit(1)
+  }
+}

--- a/packages/cli/src/lib/latitudeConfig/updateVersion.ts
+++ b/packages/cli/src/lib/latitudeConfig/updateVersion.ts
@@ -1,8 +1,8 @@
+import colors from 'picocolors'
+import findConfigFile from './findConfigFile'
 import fsExtra from 'fs-extra'
 import path from 'path'
-import colors from 'picocolors'
 import { PartialLatitudeConfig } from '$src/config'
-import { findConfigFile } from './findOrCreate'
 
 export default async function updateVersion({
   appDir,


### PR DESCRIPTION
# WHAT

We've seen some users experiencing errors fetching latitude's latest versions from npm. I suspect is because we are hard crashing when the npm view process outputs on stderr, which we should not, as it is known npm often outputs harmless warnings to stderr.