### PR TITLE
fix: properly closing mysql connection

### DIFF
--- a/.changeset/heavy-foxes-taste.md
+++ b/.changeset/heavy-foxes-taste.md
@@ -1,0 +1,5 @@
+---
+"@latitude-data/mysql-connector": patch
+---
+
+fix: properly close connection after running a query in mysql connector

--- a/packages/connectors/mysql/src/index.ts
+++ b/packages/connectors/mysql/src/index.ts
@@ -58,6 +58,8 @@ export class MysqlConnector extends BaseConnector {
           (error, results, fields) => {
             connection.release()
 
+            this.pool.end()
+
             if (error) {
               return reject(new QueryError(error.message))
             }


### PR DESCRIPTION
We were not properly closing mysql connections after running the query. Ideally we would need to change our query system so that we maintain a pool of connections open but this requires some more work. In the meantime this is a good enough compromise.

fixes #194 