### PR TITLE
Add Sentry to CLI

### DIFF
--- a/.changeset/silent-chairs-talk.md
+++ b/.changeset/silent-chairs-talk.md
@@ -1,0 +1,5 @@
+---
+"@latitude-data/cli": minor
+---
+
+Add Sentry to CLI to track errors better

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,12 @@ jobs:
         uses: changesets/action@v1
         with:
           # This expects us to have a script called release which does a build for our packages and calls changeset publish
-          publish: CLI_SENTRY_ENABLED='true' CLI_SENTRY_DSN=${{ secrets.CLI_SENTRY_DSN }} pnpm release
+          publish: |
+            TELEMETRY_URL=${{ secrets.TELEMETRY_URL }}
+            TELEMETRY_CLIENT_KEY=${{ secrets.TELEMETRY_CLIENT_KEY }}
+            CLI_SENTRY_DSN=${{ secrets.CLI_SENTRY_DSN }}
+            CLI_SENTRY_ENABLED='true'
+            pnpm release
         env:
           GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
         uses: changesets/action@v1
         with:
           # This expects us to have a script called release which does a build for our packages and calls changeset publish
-          publish: pnpm release
+          publish: CLI_SENTRY_ENABLED='true' CLI_SENTRY_DSN=${{ secrets.CLI_SENTRY_DSN }} pnpm release
         env:
           GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -55,6 +55,8 @@
   "dependencies": {
     "@inquirer/prompts": "^4.2.1",
     "@rudderstack/rudder-sdk-node": "^2.0.7",
+    "@sentry/node": "^7.108.0",
+    "@sentry/profiling-node": "^7.108.0",
     "ajv": "^8.12.0",
     "axios": "^1.6.7",
     "boxen": "^7.1.1",

--- a/packages/cli/rollup.config.mjs
+++ b/packages/cli/rollup.config.mjs
@@ -54,6 +54,8 @@ export default {
       'process.env.PACKAGE_VERSION': JSON.stringify(packageVersion),
       'process.env.CLI_SENTRY_ENABLED': JSON.stringify(process.env.CLI_SENTRY_ENABLED),
       'process.env.CLI_SENTRY_DSN': JSON.stringify(process.env.CLI_SENTRY_DSN),
+      'process.env.TELEMETRY_URL': JSON.stringify(process.env.TELEMETRY_URL),
+      'process.env.TELEMETRY_CLIENT_KEY': JSON.stringify(process.env.TELEMETRY_CLIENT_KEY),
       preventAssignment: true,
     }),
     json(),

--- a/packages/cli/rollup.config.mjs
+++ b/packages/cli/rollup.config.mjs
@@ -1,6 +1,8 @@
 import { fileURLToPath } from 'url'
 import fs from 'fs'
+import { config as dotenvConfig } from 'dotenv'
 import path from 'path'
+import { dirname, resolve as resolvePath } from 'path'
 import json from '@rollup/plugin-json'
 import { copy } from '@web/rollup-plugin-copy'
 import resolve from '@rollup/plugin-node-resolve'
@@ -8,15 +10,18 @@ import typescript from '@rollup/plugin-typescript'
 import commonjs from '@rollup/plugin-commonjs'
 import replace from '@rollup/plugin-replace'
 
+const DIRNAME = dirname(fileURLToPath(import.meta.url))
 function getPackageVersion() {
-  const __dirname = path.dirname(fileURLToPath(import.meta.url))
-  const pkgPath = path.join(__dirname, 'package.json')
+  const pkgPath = path.join(DIRNAME, 'package.json')
   return JSON.parse(fs.readFileSync(pkgPath, 'utf8')).version
 }
 
 const nodeEnv = process.env.NODE_ENV ? process.env.NODE_ENV : 'development'
 const packageVersion =
   nodeEnv === 'development' ? 'development-0.0.0' : getPackageVersion()
+
+const workspaceDotEnvPath = resolvePath(DIRNAME, '..', '..', '.env')
+dotenvConfig({ path: workspaceDotEnvPath })
 
 /**
  * @typedef {import('rollup').RollupOptions} RollupOptions
@@ -47,6 +52,8 @@ export default {
     replace({
       'process.env.NODE_ENV': JSON.stringify(nodeEnv),
       'process.env.PACKAGE_VERSION': JSON.stringify(packageVersion),
+      'process.env.CLI_SENTRY_ENABLED': JSON.stringify(process.env.CLI_SENTRY_ENABLED),
+      'process.env.CLI_SENTRY_DSN': JSON.stringify(process.env.CLI_SENTRY_DSN),
       preventAssignment: true,
     }),
     json(),
@@ -72,5 +79,7 @@ export default {
     '@rudderstack/rudder-sdk-node',
     'configstore',
     'latest-version',
+    '@sentry/node',
+    '@sentry/profiling-node',
   ],
 }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -10,6 +10,9 @@ import startCommand from './commands/start'
 import telemetryCommand from './commands/telemetry'
 import updateCommand from './commands/update'
 import { onError } from './utils'
+import initSentry from '$src/integrations/sentry'
+
+initSentry()
 
 const CLI = sade('latitude')
 

--- a/packages/cli/src/integrations/sentry.test.ts
+++ b/packages/cli/src/integrations/sentry.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { nodeProfilingIntegration } from '@sentry/profiling-node'
+import initSentry from './sentry'
+
+const mockedSentryInit = vi.hoisted(() => vi.fn())
+vi.mock('@sentry/node', async () => {
+  const original = await vi.importActual('@sentry/node')
+  return {
+    ...original,
+    init: mockedSentryInit,
+  }
+})
+
+describe('initSentry', () => {
+  afterEach(() => {
+    mockedSentryInit.mockRestore()
+    vi.unstubAllEnvs()
+  })
+
+  it('uses Sentry', () => {
+    vi.stubEnv('CLI_SENTRY_ENABLED', 'true')
+    vi.stubEnv('CLI_SENTRY_DSN', 'your-sentry-dsn-url')
+    initSentry()
+    expect(mockedSentryInit).toHaveBeenCalledWith({
+      dsn: 'your-sentry-dsn-url',
+      integrations: [nodeProfilingIntegration()],
+      tracesSampleRate: 1.0,
+      profilesSampleRate: 1.0,
+    })
+  })
+
+  it('does not uses Sentry', () => {
+    vi.stubEnv('CLI_SENTRY_ENABLED', '')
+    vi.stubEnv('CLI_SENTRY_DSN', '')
+    initSentry()
+    expect(mockedSentryInit).not.toHaveBeenCalled()
+  })
+})

--- a/packages/cli/src/integrations/sentry.ts
+++ b/packages/cli/src/integrations/sentry.ts
@@ -1,0 +1,20 @@
+import * as Sentry from '@sentry/node'
+import { nodeProfilingIntegration } from '@sentry/profiling-node'
+
+export default function initSentry() {
+  const enabled = process.env.CLI_SENTRY_ENABLED
+  const dsn = process.env.CLI_SENTRY_DSN
+
+  const isEnabled = dsn && enabled === 'true'
+
+  if (!isEnabled) return
+
+  Sentry.init({
+    dsn,
+    integrations: [nodeProfilingIntegration()],
+    // Performance Monitoring
+    tracesSampleRate: 1.0, //  Capture 100% of the transactions
+    // Set sampling rate for profiling - this is relative to tracesSampleRate
+    profilesSampleRate: 1.0,
+  })
+}

--- a/packages/cli/src/lib/telemetry/index.test.ts
+++ b/packages/cli/src/lib/telemetry/index.test.ts
@@ -60,6 +60,8 @@ const consoleMock = vi.spyOn(console, 'log').mockImplementation(() => undefined)
 
 describe('Telemetry', () => {
   beforeEach(() => {
+    vi.stubEnv('TELEMETRY_CLIENT_KEY', 'secret-telemetry-key')
+    vi.stubEnv('TELEMETRY_URL', 'telemetry-url')
     mockedStoreGet.mockReturnValue({
       enabled: undefined,
       anonymousUserId: undefined,
@@ -68,6 +70,7 @@ describe('Telemetry', () => {
 
   afterEach(() => {
     consoleMock.mockReset()
+    vi.unstubAllEnvs()
   })
 
   it('should create an instance', () => {
@@ -77,10 +80,8 @@ describe('Telemetry', () => {
   it('initialize rudderstack', () => {
     new Telemetry()
     expect(MockedRudderStack).toHaveBeenCalledWith(
-      '2daExoSEzxW3lPbRFQVoYIGh0Rb',
-      {
-        dataPlaneUrl: 'https://latitudecmggvg.dataplane.rudderstack.com',
-      },
+      'secret-telemetry-key',
+      { dataPlaneUrl: 'telemetry-url' },
     )
   })
 

--- a/packages/cli/src/lib/telemetry/index.ts
+++ b/packages/cli/src/lib/telemetry/index.ts
@@ -7,8 +7,6 @@ import type { TelemetryEvent, TelemetryEventType } from './events'
 import chalk from 'chalk'
 import configStore from '$src/lib/configStore'
 
-const CLIENT_KEY = '2daExoSEzxW3lPbRFQVoYIGh0Rb'
-const ANALYTICS_URL = 'https://latitudecmggvg.dataplane.rudderstack.com'
 type TelemetryConfig = {
   enabled: boolean | undefined
   anonymousUserId: string | undefined
@@ -105,8 +103,10 @@ export class Telemetry {
   }
 
   private identifyAnonymous(enabled: boolean) {
+    const anonymousId = this.anonymousId
+
     this.client?.identify({
-      anonymousId: this.anonymousId,
+      anonymousId,
       context: {
         telemetry: { enabled },
         cliVersion: process.env.PACKAGE_VERSION,
@@ -139,12 +139,9 @@ export class Telemetry {
     return configStore.get('telemetry')
   }
 
-  // TODO: Provision TELEMETRY_CLIENT_KEY and TELEMETRY_URL
-  // We don't want to use telemetry in development mode
-  // we will provision this for the published CLI
   private get credentials(): TelemetryCredentials | undefined {
-    const clientKey = process.env.TELEMETRY_CLIENT_KEY ?? CLIENT_KEY
-    const clientUrl = process.env.TELEMETRY_URL ?? ANALYTICS_URL
+    const clientKey = process.env.TELEMETRY_CLIENT_KEY
+    const clientUrl = process.env.TELEMETRY_URL
     if (!clientKey || !clientUrl) return undefined
 
     return {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,7 +125,7 @@ importers:
         version: 5.3.3
       vite:
         specifier: ^5.0.3
-        version: 5.0.12(@types/node@20.11.25)
+        version: 5.0.12(@types/node@18.19.15)
       vite-node:
         specifier: ^1.3.1
         version: 1.3.1
@@ -141,6 +141,12 @@ importers:
       '@rudderstack/rudder-sdk-node':
         specifier: ^2.0.7
         version: 2.0.7(tslib@2.6.2)
+      '@sentry/node':
+        specifier: ^7.108.0
+        version: 7.108.0
+      '@sentry/profiling-node':
+        specifier: ^7.108.0
+        version: 7.108.0
       ajv:
         specifier: ^8.12.0
         version: 8.12.0
@@ -473,7 +479,7 @@ importers:
         version: 5.3.3
       vite:
         specifier: ^5.0.11
-        version: 5.0.12(@types/node@20.11.25)
+        version: 5.0.12(@types/node@18.19.15)
       vitest:
         specifier: ^1.2.0
         version: 1.2.2(jsdom@24.0.0)
@@ -5561,6 +5567,55 @@ packages:
     resolution: {integrity: sha512-6i/8UoL0P5y4leBIGzvkZdS85RDMG9y1ihZzmTZQ5LdHUYmZ7pKFoj8X0236s3lusPs1Fa5HTQUpwI+UfTcmeA==}
     dev: true
 
+  /@sentry-internal/tracing@7.108.0:
+    resolution: {integrity: sha512-zuK5XsTsb+U+hgn3SPetYDAogrXsM16U/LLoMW7+TlC6UjlHGYQvmX3o+M2vntejoU1QZS8m1bCAZSMWEypAEw==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@sentry/core': 7.108.0
+      '@sentry/types': 7.108.0
+      '@sentry/utils': 7.108.0
+    dev: false
+
+  /@sentry/core@7.108.0:
+    resolution: {integrity: sha512-I/VNZCFgLASxHZaD0EtxZRM34WG9w2gozqgrKGNMzAymwmQ3K9g/1qmBy4e6iS3YRptb7J5UhQkZQHrcwBbjWQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@sentry/types': 7.108.0
+      '@sentry/utils': 7.108.0
+    dev: false
+
+  /@sentry/node@7.108.0:
+    resolution: {integrity: sha512-pMxc9txnDDkU4Z8k2Uw/DPSLPehNtWV3mjJ3+my0AMORGYrXLkJI93tddlE5z/7k+GEJdj1HsOLgxUN0OU+HGA==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@sentry-internal/tracing': 7.108.0
+      '@sentry/core': 7.108.0
+      '@sentry/types': 7.108.0
+      '@sentry/utils': 7.108.0
+    dev: false
+
+  /@sentry/profiling-node@7.108.0:
+    resolution: {integrity: sha512-P0yD4h8pACgSlD74q/QrMLyhQYs6CR1cTB8VVFsOPuymwUTaS+QTGOqIwQVEXAL9Bit5ds0ZbrZnJTP8GHOETg==}
+    engines: {node: '>=8.0.0'}
+    hasBin: true
+    requiresBuild: true
+    dependencies:
+      detect-libc: 2.0.2
+      node-abi: 3.54.0
+    dev: false
+
+  /@sentry/types@7.108.0:
+    resolution: {integrity: sha512-bKtHITmBN3kqtqE5eVvL8mY8znM05vEodENwRpcm6TSrrBjC2RnwNWVwGstYDdHpNfFuKwC8mLY9bgMJcENo8g==}
+    engines: {node: '>=8'}
+    dev: false
+
+  /@sentry/utils@7.108.0:
+    resolution: {integrity: sha512-a45yEFD5qtgZaIFRAcFkG8C8lnDzn6t4LfLXuV4OafGAy/3ZAN3XN8wDnrruHkiUezSSANGsLg3bXaLW/JLvJw==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@sentry/types': 7.108.0
+    dev: false
+
   /@sinclair/typebox@0.27.8:
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
     dev: true
@@ -6186,7 +6241,7 @@ packages:
       fs-extra: 11.2.0
       magic-string: 0.30.6
       svelte: 4.2.10
-      vite: 5.0.12(@types/node@20.11.25)
+      vite: 5.0.12(@types/node@18.19.15)
     transitivePeerDependencies:
       - babel-plugin-macros
     dev: true
@@ -6295,7 +6350,7 @@ packages:
       magic-string: 0.30.6
       rollup: 3.29.4
       typescript: 5.3.3
-      vite: 5.0.12(@types/node@20.11.25)
+      vite: 5.0.12(@types/node@18.19.15)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -6675,7 +6730,7 @@ packages:
       svelte-preprocess: 5.1.3(@babel/core@7.23.3)(postcss@8.4.35)(svelte@4.2.10)(typescript@5.3.3)
       sveltedoc-parser: 4.2.1
       ts-dedent: 2.2.0
-      vite: 5.0.12(@types/node@20.11.25)
+      vite: 5.0.12(@types/node@18.19.15)
     transitivePeerDependencies:
       - '@babel/core'
       - '@preact/preset-vite'
@@ -6727,7 +6782,7 @@ packages:
       '@storybook/svelte': 7.6.17(svelte@4.2.10)
       '@storybook/svelte-vite': 7.6.17(@babel/core@7.23.3)(postcss@8.4.35)(svelte@4.2.10)(typescript@5.3.3)(vite@5.0.12)
       svelte: 4.2.10
-      vite: 5.0.12(@types/node@20.11.25)
+      vite: 5.0.12(@types/node@18.19.15)
     transitivePeerDependencies:
       - '@babel/core'
       - '@preact/preset-vite'
@@ -6852,7 +6907,7 @@ packages:
       sirv: 2.0.4
       svelte: 4.2.10
       tiny-glob: 0.2.9
-      vite: 5.0.12(@types/node@20.11.25)
+      vite: 5.0.12(@types/node@18.19.15)
     dev: true
 
   /@sveltejs/kit@2.5.0(@sveltejs/vite-plugin-svelte@3.0.0)(svelte@4.2.7)(vite@5.0.12):
@@ -6879,7 +6934,7 @@ packages:
       sirv: 2.0.4
       svelte: 4.2.7
       tiny-glob: 0.2.9
-      vite: 5.0.12(@types/node@20.11.25)
+      vite: 5.0.12(@types/node@18.19.15)
     dev: true
 
   /@sveltejs/package@2.2.6(svelte@4.2.10)(typescript@5.3.3):
@@ -6910,7 +6965,7 @@ packages:
       '@sveltejs/vite-plugin-svelte': 2.5.3(svelte@4.2.10)(vite@5.0.12)
       debug: 4.3.4(supports-color@8.1.1)
       svelte: 4.2.10
-      vite: 5.0.12(@types/node@20.11.25)
+      vite: 5.0.12(@types/node@18.19.15)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6926,7 +6981,7 @@ packages:
       '@sveltejs/vite-plugin-svelte': 3.0.0(svelte@4.2.10)(vite@5.0.12)
       debug: 4.3.4(supports-color@8.1.1)
       svelte: 4.2.10
-      vite: 5.0.12(@types/node@20.11.25)
+      vite: 5.0.12(@types/node@18.19.15)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6942,7 +6997,7 @@ packages:
       '@sveltejs/vite-plugin-svelte': 3.0.0(svelte@4.2.7)(vite@5.0.12)
       debug: 4.3.4(supports-color@8.1.1)
       svelte: 4.2.7
-      vite: 5.0.12(@types/node@20.11.25)
+      vite: 5.0.12(@types/node@18.19.15)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6961,7 +7016,7 @@ packages:
       magic-string: 0.30.6
       svelte: 4.2.10
       svelte-hmr: 0.15.3(svelte@4.2.10)
-      vite: 5.0.12(@types/node@20.11.25)
+      vite: 5.0.12(@types/node@18.19.15)
       vitefu: 0.2.5(vite@5.0.12)
     transitivePeerDependencies:
       - supports-color
@@ -6981,7 +7036,7 @@ packages:
       magic-string: 0.30.6
       svelte: 4.2.10
       svelte-hmr: 0.15.3(svelte@4.2.10)
-      vite: 5.0.12(@types/node@20.11.25)
+      vite: 5.0.12(@types/node@18.19.15)
       vitefu: 0.2.5(vite@5.0.12)
     transitivePeerDependencies:
       - supports-color
@@ -7001,7 +7056,7 @@ packages:
       magic-string: 0.30.6
       svelte: 4.2.7
       svelte-hmr: 0.15.3(svelte@4.2.7)
-      vite: 5.0.12(@types/node@20.11.25)
+      vite: 5.0.12(@types/node@18.19.15)
       vitefu: 0.2.5(vite@5.0.12)
     transitivePeerDependencies:
       - supports-color
@@ -16765,9 +16820,6 @@ packages:
   /sqlite3@5.1.7:
     resolution: {integrity: sha512-GGIyOiFaG+TUra3JIfkI/zGP8yZYLPQ0pl1bH+ODjiX57sPhrLU5sQJn1y9bDKZUFYkX1crlrPfSYt0BKKdkog==}
     requiresBuild: true
-    peerDependenciesMeta:
-      node-gyp:
-        optional: true
     dependencies:
       bindings: 1.5.0
       node-addon-api: 7.1.0
@@ -18285,7 +18337,7 @@ packages:
       debug: 4.3.4(supports-color@8.1.1)
       pathe: 1.1.2
       picocolors: 1.0.0
-      vite: 5.0.12(@types/node@20.11.25)
+      vite: 5.0.12(@types/node@18.19.15)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -18327,7 +18379,7 @@ packages:
       debug: 4.3.4(supports-color@8.1.1)
       pathe: 1.1.2
       picocolors: 1.0.0
-      vite: 5.0.12(@types/node@20.11.25)
+      vite: 5.0.12(@types/node@18.19.15)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -18595,7 +18647,7 @@ packages:
       vite:
         optional: true
     dependencies:
-      vite: 5.0.12(@types/node@20.11.25)
+      vite: 5.0.12(@types/node@18.19.15)
     dev: true
 
   /vitest@1.2.2(@types/node@20.10.6):
@@ -18699,7 +18751,7 @@ packages:
       strip-literal: 1.3.0
       tinybench: 2.6.0
       tinypool: 0.8.2
-      vite: 5.0.12(@types/node@20.11.25)
+      vite: 5.0.12(@types/node@18.19.15)
       vite-node: 1.2.2
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
@@ -18754,7 +18806,7 @@ packages:
       strip-literal: 2.0.0
       tinybench: 2.6.0
       tinypool: 0.8.2
-      vite: 5.0.12(@types/node@20.11.25)
+      vite: 5.0.12(@types/node@18.19.15)
       vite-node: 1.3.1
       why-is-node-running: 2.2.2
     transitivePeerDependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -6,7 +6,9 @@
     "PACKAGE_VERSION",
     "LATITUDE_TARGET",
     "TELEMETRY_CLIENT_KEY",
-    "TELEMETRY_URL"
+    "TELEMETRY_URL",
+    "CLI_SENTRY_ENABLED",
+    "CLI_SENTRY_DSN"
   ],
   "pipeline": {
     "prettier": {


### PR DESCRIPTION
# What?
Fix this issue https://github.com/latitude-dev/latitude/issues/171

### TODO
- [x] Add Sentry to CLI
- [x] Configure Sentry with a env variable
- [x] QA it in development with the DSN in my `.env` file
- [x] Configure CI release.yml to build CLI with Sentry enabled. Test and Linter CI task should not enable Sentry.
- [x] Add `CLI_SENTRY_DSN` to github as env variable for building the CLI with Sentry activated. 
- [x] Add `TELEMETRY_URL` and `TELEMETRY_CLIENT_KEY` as github actions secrets
- [x] ~~Think if makes sense to add Sentry to `apps/server` SvelteKit app and how to do it to make it configurable at deploy time~~ Does not makes sense atm
- [x] ~~Configure [Source Maps for CLI for Sentry](https://docs.sentry.io/platforms/node/sourcemaps/)~~ I'll do this in another moment if we see it's necessary
