### PR TITLE
Fix show template selector when init a project with CLI

### DIFF
--- a/.changeset/pink-toes-lie.md
+++ b/.changeset/pink-toes-lie.md
@@ -1,0 +1,5 @@
+---
+"@latitude-data/cli": minor
+---
+
+Fix template selector not shown when starting a project

--- a/packages/cli/src/commands/dev/index.ts
+++ b/packages/cli/src/commands/dev/index.ts
@@ -34,19 +34,19 @@ const buildServerProps = async ({
   }
   const latitudeJson = await findOrCreateConfigFile()
 
-  const checker = new InstalledVersionChecker(
-    config.rootDir,
+  const checker = new InstalledVersionChecker({
+    cwd: config.rootDir,
     // TODO: Fix this. Version should never be undefined in reality.
-    latitudeJson.data.version as string,
-  )
+    configVersion: latitudeJson.data.version as string,
+  })
 
   return checker.isDifferent()
     ? {
         ...server,
-        onReady: () => {
-          checker.displayMessage()
+        onReady: (devUrl) => {
+          checker.displayMessage(devUrl)
         },
-      }
+      } as DevServerProps
     : server
 }
 

--- a/packages/cli/src/commands/dev/runDev.ts
+++ b/packages/cli/src/commands/dev/runDev.ts
@@ -14,7 +14,7 @@ export type DevServerProps = {
   host?: string
   open?: boolean
   verbose?: boolean
-  onReady?: () => void
+  onReady?: (devUrl: string) => void
 }
 
 let building = true
@@ -101,14 +101,15 @@ const onStdout =
       console.log(logmsg)
     }
 
+    const devUrl = `🚀 ${colors.blue('Server running on')} \n\nhttp://localhost:${appPort}`
     if (building && logmsg.includes('ready in')) {
       cleanTerminal()
       if (onReady) {
-        onReady()
+        onReady(devUrl)
       } else {
         boxedMessage({
           title: 'Latitude server',
-          text: `${colors.blue('Listening on')} http://localhost:${appPort}`,
+          text: devUrl,
           color: 'green',
         })
       }

--- a/packages/cli/src/commands/start/index.ts
+++ b/packages/cli/src/commands/start/index.ts
@@ -34,7 +34,7 @@ async function welcomeMessage() {
 export default async function startCommand({
   name,
   port,
-  template = TemplateUrl.default,
+  template,
   open = false,
 }: {
   open: boolean
@@ -66,6 +66,7 @@ export default async function startCommand({
     template: choosenTemplate,
     force,
   })) as string
+
   config.rootDir = rootDir
 
   await setupApp()

--- a/packages/cli/src/lib/latitudeConfig/InstalledVersionChecker.ts
+++ b/packages/cli/src/lib/latitudeConfig/InstalledVersionChecker.ts
@@ -6,7 +6,13 @@ export default class InstalledVersionChecker {
   public installed: string | null = null
   public config: string | null = null
 
-  constructor(cwd: string, configVersion: string) {
+  constructor({
+    cwd,
+    configVersion,
+  }: {
+    cwd: string
+    configVersion: string
+  }) {
     this.installed = getInstalledVersion(cwd)
     this.config = configVersion
   }
@@ -15,18 +21,25 @@ export default class InstalledVersionChecker {
     return this.installed !== this.config
   }
 
-  displayMessage() {
+  displayMessage(devUrl: string) {
     const message = `
+      ${devUrl}
+
+      ---------
+
+      You're using a different version of Latitude server.
       Your machine: ${colors.red(this.installed)}
-      This project: ${colors.green(this.config)}
+      This project (latitude.json): ${colors.green(this.config)}
 
       Please run to fix this issue:
       ${colors.blue('latitude update --fix')}
+
+
     `
     boxedMessage({
       text: message,
-      title: 'Different Latitude version detected',
-      color: 'yellow',
+      title: 'Latitude server',
+      color: 'green',
     })
   }
 }

--- a/packages/cli/tests/e2e/start.cjs
+++ b/packages/cli/tests/e2e/start.cjs
@@ -4,7 +4,15 @@ const { spawn, spawnSync } = require('child_process')
 
 let ok = false
 
-spawnSync('node', [path.join(__dirname, '../../dist/cli.js'), 'telemetry', '--disable'])
+// Disable telemetry
+spawnSync(
+  'node',
+  [
+    path.join(__dirname, '../../dist/cli.js'),
+    'telemetry',
+    '--disable'
+  ]
+)
 
 const spawned = spawn('node', [
   path.join(__dirname, '../../dist/cli.js'),

--- a/turbo.json
+++ b/turbo.json
@@ -1,7 +1,13 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "globalDependencies": ["**/.env.*local"],
-  "globalEnv": ["NODE_ENV", "PACKAGE_VERSION", "LATITUDE_TARGET"],
+  "globalEnv": [
+    "NODE_ENV",
+    "PACKAGE_VERSION",
+    "LATITUDE_TARGET",
+    "TELEMETRY_CLIENT_KEY",
+    "TELEMETRY_URL"
+  ],
   "pipeline": {
     "prettier": {
       "dependsOn": ["^prettier"],


### PR DESCRIPTION
# What? 
Fix template selector not shown when creating a new project


### TODO
- [x] Fix show template selector when starting a project with CLI
- [x] Show server running URL when showing different version warning


<img width="484" alt="image" src="https://github.com/latitude-dev/latitude/assets/49499/fa0396f0-f6c8-48f2-a431-a8bb4e866f3b">

<img width="516" alt="image" src="https://github.com/latitude-dev/latitude/assets/49499/019733b3-15c2-4614-9e73-a1779628e124">

