### PR TITLE
Fix: Latitude run watch not working

### DIFF
--- a/.changeset/witty-lizards-cough.md
+++ b/.changeset/witty-lizards-cough.md
@@ -1,0 +1,6 @@
+---
+"@latitude-data/cli": patch
+"@latitude-data/server": patch
+---
+
+Fix: CLI run command was ignoring --watch flag.

--- a/apps/server/scripts/run_query/index.ts
+++ b/apps/server/scripts/run_query/index.ts
@@ -1,48 +1,59 @@
 import { QUERIES_DIR } from '../../src/lib/query_service/find_or_compute'
 import findQueryFile from '@latitude-data/query_service'
 import { createConnector } from '@latitude-data/connector-factory'
-import { render, displayResults, displayError } from './result_display'
+import QueryDisplay from './result_display'
 import chokidar from 'chokidar'
 
-const args = process.argv.slice(2)
-if (args.length < 1) {
-  console.error('Usage: run <query> [options]')
-  process.exit(1)
-}
-const watch = args[0] === '--watch'
-const queryPath = args[0 + Number(watch)]!
-let options
-try {
-  options = args[1 + Number(watch)] ? JSON.parse(args[1 + Number(watch)]!) : {}
-} catch (e) {
-  console.error('Options must be a valid JSON string')
-  process.exit(1)
+type CommandArgs = {
+  queryPath: string
+  watch: boolean
+  options: { [key: string]: string }
 }
 
-async function run(query: string, options: { [key: string]: string }) {
+function getArgs(): CommandArgs {
+  const args = process.argv.slice(2)
+  if (args.length < 2) {
+    console.error('Usage: run <query> <watch:true|false> [options]')
+    process.exit(1)
+  }
+  const watch = args[1] === 'true'
+  const queryPath = args[0]!
+  let options
+  try {
+    options = args.length < 3 ? {} : JSON.parse(args[2]!)
+  } catch (e) {
+    console.error('Options must be a valid JSON string')
+    process.exit(1)
+  }
+  return { queryPath, watch, options }
+}
+
+async function runQuery(query: string, options: { [key: string]: string }) {
   try {
     const { sourcePath, queryPath } = await findQueryFile(QUERIES_DIR, query)
     const connector = createConnector(sourcePath)
-    
+
     const startTime = Date.now()
     const result = await connector.run({ queryPath, params: options })
     const totalTime = Date.now() - startTime
 
-    displayResults(result, totalTime)
+    QueryDisplay.displayResults(result, totalTime)
   } catch (e) {
-    displayError(e)
+    QueryDisplay.displayError(e)
   }
 }
 
-if (watch) {
+const args = getArgs()
+
+if (args.watch) {
   const watcher = chokidar.watch(QUERIES_DIR, {
     ignored: /(^|[/\\])\../,
   })
-  
+
   watcher.on('change', () => {
-    run(queryPath, options)
+    runQuery(args.queryPath, args.options)
   })
 }
 
-render()
-run(queryPath, options)
+QueryDisplay.render()
+runQuery(args.queryPath, args.options)

--- a/apps/server/scripts/run_query/result_display.ts
+++ b/apps/server/scripts/run_query/result_display.ts
@@ -2,156 +2,198 @@ import QueryResult from '@latitude-data/query_result'
 import { screen, text, box, listtable, type Widgets } from 'blessed'
 import { CompileError } from '@latitude-data/sql-compiler'
 
-const display: Widgets.Screen = screen({
-  smartCSR: true, // Enable smart window resizing
-  title: 'Results',
-})
+export default class QueryDisplay {
+  private static instance: QueryDisplay
 
-const header = text({
-  top: 0,
-  content: `Loading...`,
-  tags: true,
-  style: {
-    fg: 'blue',
-    bold: true,
-  },
-})
+  private display: Widgets.Screen
+  private header: Widgets.TextElement
+  private footer: Widgets.TextElement
+  private body: Widgets.BoxElement
+  private bodyChildren: Widgets.BlessedElement[]
 
-const footer = text({
-  bottom: 0,
-  content: '↑↓ ←→ to scroll, Esc / Ctrl+C / Q to exit',
-  tags: true,
-  style: {
-    fg: 'blue',
-    bold: true,
-  },
-})
+  private constructor() {
+    this.display = screen({
+      smartCSR: true,
+      title: 'Results',
+    })
 
-const body = box({
-  top: 1,
-  bottom: 1,
-  width: '100%',
-  keys: true,
-  mouse: true,
-  border: {
-    type: 'line',
-  },
-  style: {
-    border: {
-      fg: 'gray',
-    },
-    header: {
-      fg: 'black',
-      bg: 'blue',
-    },
-    cell: {
-      fg: 'white',
-      bg: 'black',
-    },
-  },
-  align: 'center',
-})
-const bodyChildren: Widgets.BlessedElement[] = []
+    this.header = text({
+      top: 0,
+      content: `Loading...`,
+      tags: true,
+      style: {
+        fg: 'blue',
+        bold: true,
+      },
+    })
 
-display.append(header)
-display.append(body)
-display.append(footer)
+    this.footer = text({
+      bottom: 0,
+      content: '↑↓ ←→ to scroll, Esc / Ctrl+C / Q to exit',
+      tags: true,
+      style: {
+        fg: 'blue',
+        bold: true,
+      },
+    })
 
-display.key(['escape', 'q', 'C-c'], () => process.exit(0))
-
-export function render() {
-  display.render()
-}
-
-function setBodyContent(content: Widgets.BlessedElement) {
-  bodyChildren.forEach((child) => body.remove(child))
-  bodyChildren.length = 0
-  body.setContent('')
-
-  bodyChildren.push(content)
-  body.append(content)
-}
-
-function msToHuman(ms: number) {
-  if (ms < 1000) return `${ms}ms`
-
-  const secondsMod = (ms % 1000).toString().padStart(3, '0')
-  const seconds = (ms / 1000 % 60).toFixed(0).padStart(2, '0')
-  if (ms < 60 * 1000) return `${seconds}.${secondsMod}s`
-
-  let minutes = (ms / 1000 / 60).toFixed(0).padStart(2, '0')
-  if (ms < 60 * 60 * 1000) return `${minutes}:${seconds}.${secondsMod}`
-
-  minutes = (ms / 1000 / 60 % 60).toFixed(0).padStart(2, '0')
-  const hours = (ms / 1000 / 60 / 60).toFixed(0).padStart(2, '0')
-  return `${hours}:${minutes}:${seconds}`
-}
-
-export function displayResults(results: QueryResult, loadTime: number) {
-  header.setContent(`Load time: ${msToHuman(loadTime)}, Rows: ${results.rowCount}`)
-  const table: Widgets.ListTableElement = listtable({
-    keys: true,
-    mouse: true,
-    border: {
-      type: 'line',
-    },
-    style: {
+    this.body = box({
+      top: 1,
+      bottom: 1,
+      width: '100%',
+      keys: true,
+      mouse: true,
       border: {
-        fg: 'gray',
+        type: 'line',
       },
-      header: {
-        fg: 'black',
-        bg: 'blue',
+      style: {
+        border: {
+          fg: 'gray',
+        },
+        header: {
+          fg: 'black',
+          bg: 'blue',
+        },
+        cell: {
+          fg: 'white',
+          bg: 'black',
+        },
       },
-      cell: {
-        fg: 'white',
-        bg: 'black',
-      },
-    },
-    align: 'left',
-  });
+      align: 'center',
+    })
+    this.bodyChildren = []
 
-  const tableData: string[][] = [
-    results.fields.map((field) => field.name),
-    ...results.rows.map((row) => row.map((cell) => String(cell))),
-  ]
+    this.display.append(this.header)
+    this.display.append(this.body)
+    this.display.append(this.footer)
 
-  let horizontalScrollOffset = 0
-  function scrollTable(offset: number) {
-    horizontalScrollOffset = Math.max(0, Math.min(horizontalScrollOffset + offset, tableData[0].length - 1))
-    const vScroll = table.getScroll()
-    table.setData(tableData.map((row) => row.slice(horizontalScrollOffset)))
-    table.select(vScroll)
-    render()
+    this.display.key(['escape', 'q', 'C-c'], () => process.exit(0))
   }
 
-  setBodyContent(table)
-
-  table.key(['left', 'h'], () => scrollTable(-1))
-  table.key(['right', 'l'], () => scrollTable(1))
-
-  table.focus()
-  scrollTable(0)
-}
-
-export function displayError(error: Error) {
-  header.setContent('Error')
-  let errorMsg = error.message
-  if (error instanceof CompileError) {
-    errorMsg = error.toString()
+  public render() {
+    this.display.render()
   }
-  const errorBox = box({
-    content: errorMsg,
-    tags: true,
-    style: {
-      fg: 'red',
-      bold: true,
-    },
-  })
-  setBodyContent(errorBox)
-  render()
-}
 
-export function exit() {
-  display.destroy()
+  public setBodyContent(content: Widgets.BlessedElement) {
+    this.bodyChildren.forEach((child) => this.body.remove(child))
+    this.bodyChildren.length = 0
+    this.body.setContent('')
+
+    this.bodyChildren.push(content)
+    this.body.append(content)
+  }
+
+  static msToHuman(ms: number) {
+    if (ms < 1000) return `${ms}ms`
+
+    const secondsMod = (ms % 1000).toString().padStart(3, '0')
+    const seconds = ((ms / 1000) % 60).toFixed(0).padStart(2, '0')
+    if (ms < 60 * 1000) return `${seconds}.${secondsMod}s`
+
+    let minutes = (ms / 1000 / 60).toFixed(0).padStart(2, '0')
+    if (ms < 60 * 60 * 1000) return `${minutes}:${seconds}.${secondsMod}`
+
+    minutes = ((ms / 1000 / 60) % 60).toFixed(0).padStart(2, '0')
+    const hours = (ms / 1000 / 60 / 60).toFixed(0).padStart(2, '0')
+    return `${hours}:${minutes}:${seconds}`
+  }
+
+  public displayResults(results: QueryResult, loadTime: number) {
+    this.header.setContent(
+      `Load time: ${QueryDisplay.msToHuman(loadTime)}, Rows: ${
+        results.rowCount
+      }`,
+    )
+    const table: Widgets.ListTableElement = listtable({
+      keys: true,
+      mouse: true,
+      border: {
+        type: 'line',
+      },
+      style: {
+        border: {
+          fg: 'gray',
+        },
+        header: {
+          fg: 'black',
+          bg: 'blue',
+        },
+        cell: {
+          fg: 'white',
+          bg: 'black',
+        },
+      },
+      align: 'left',
+    })
+
+    const tableData: string[][] = [
+      results.fields.map((field) => field.name),
+      ...results.rows.map((row) => row.map((cell) => String(cell))),
+    ]
+
+    let horizontalScrollOffset = 0
+    function scrollTable(offset: number) {
+      horizontalScrollOffset = Math.max(
+        0,
+        Math.min(horizontalScrollOffset + offset, tableData[0].length - 1),
+      )
+      const vScroll = table.getScroll()
+      table.setData(tableData.map((row) => row.slice(horizontalScrollOffset)))
+      table.select(vScroll)
+      this.render()
+    }
+
+    this.setBodyContent(table)
+
+    table.key(['left', 'h'], () => scrollTable(-1))
+    table.key(['right', 'l'], () => scrollTable(1))
+
+    table.focus()
+    scrollTable(0)
+  }
+
+  public displayError(error: Error) {
+    this.header.setContent('Error')
+    let errorMsg = error.message
+    if (error instanceof CompileError) {
+      errorMsg = error.toString()
+    }
+    const errorBox = box({
+      content: errorMsg,
+      tags: true,
+      style: {
+        fg: 'red',
+        bold: true,
+      },
+    })
+    this.setBodyContent(errorBox)
+    this.render()
+  }
+
+  public exit() {
+    this.display.destroy()
+  }
+
+  public static getInstance(): QueryDisplay {
+    if (!QueryDisplay.instance) {
+      QueryDisplay.instance = new QueryDisplay()
+    }
+    return QueryDisplay.instance
+  }
+
+  public static render() {
+    QueryDisplay.getInstance().render()
+  }
+
+  public static displayResults(results: QueryResult, loadTime: number) {
+    QueryDisplay.getInstance().displayResults(results, loadTime)
+  }
+
+  public static displayError(error: Error) {
+    QueryDisplay.getInstance().displayError(error)
+  }
+
+  public static exit() {
+    QueryDisplay.getInstance().exit()
+  }
 }

--- a/packages/cli/src/commands/run/index.ts
+++ b/packages/cli/src/commands/run/index.ts
@@ -15,8 +15,8 @@ async function run(
   const args = [
     'run',
     'query',
-    watch ? '--watch' : '',
     queryName,
+    watch ? 'true' : 'false',
     JSON.stringify(buildParams(opts?.param || [])),
   ].filter(Boolean)
 


### PR DESCRIPTION
Latitude run was working by invoking the `query` script in the server app. The invoking command was `npm run query --watch <queryPath> <queryParams>`. This invoked the script with the following arguments: `["--watch", <queryPath>, <queryParams>]` (of course)

For some reason I do not understand, now npm decided not to pass dashed flags to the script, so it now was invoking the script with `[<queryPath>, <queryParams>]`, completely ignoring the `watch` flag.

I have changed the script so that now it expects 3 arguments, instead of 2 arguments and a flag. Not it must be invoked like this: `npm run query <queryPath> <watch:true|false> <queryParams>`