### PR TITLE
feature: relax vscode version requirements a bit

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1129,7 +1129,7 @@ importers:
         specifier: 18.x
         version: 18.19.15
       '@types/vscode':
-        specifier: ^1.87.0
+        specifier: ^1.86.0
         version: 1.87.0
       '@vscode/test-cli':
         specifier: ^0.0.6
@@ -16771,9 +16771,6 @@ packages:
   /sqlite3@5.1.7:
     resolution: {integrity: sha512-GGIyOiFaG+TUra3JIfkI/zGP8yZYLPQ0pl1bH+ODjiX57sPhrLU5sQJn1y9bDKZUFYkX1crlrPfSYt0BKKdkog==}
     requiresBuild: true
-    peerDependenciesMeta:
-      node-gyp:
-        optional: true
     dependencies:
       bindings: 1.5.0
       node-addon-api: 7.1.0

--- a/tools/latitude-vscode/package.json
+++ b/tools/latitude-vscode/package.json
@@ -11,7 +11,7 @@
   },
   "publisher": "LatitudeData",
   "engines": {
-    "vscode": "^1.87.0"
+    "vscode": "^1.86.0"
   },
   "categories": [
     "Other"
@@ -105,7 +105,7 @@
     "@types/mocha": "^10.0.6",
     "@types/mock-fs": "^4.13.4",
     "@types/node": "18.x",
-    "@types/vscode": "^1.87.0",
+    "@types/vscode": "^1.86.0",
     "@vscode/test-cli": "^0.0.6",
     "@vscode/test-electron": "^2.3.9",
     "chai": "^5.1.0",


### PR DESCRIPTION
We are requiring the latest vscode version (1.87), but some vscode forks are a bit behind. Relaxing our requirements a bit to add support for those forks.

Related #212 