### PR TITLE
Fix: reactiveToParams debouncing even when results are cached

### DIFF
--- a/.changeset/hip-stingrays-sniff.md
+++ b/.changeset/hip-stingrays-sniff.md
@@ -1,0 +1,5 @@
+---
+"@latitude-data/server": patch
+---
+
+Adding a reactiveToParams time will no longer wait to debounce if the data is already cached.

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -32,6 +32,7 @@
     "@types/estree": "^1.0.1",
     "@types/lodash-es": "^4.17.12",
     "@types/mock-fs": "^4.13.4",
+    "@types/uuid": "^9.0.8",
     "autoprefixer": "^10.4.17",
     "blessed": "^0.1.81",
     "chokidar": "^3.5.3",
@@ -45,6 +46,7 @@
     "tailwindcss": "^3.4.1",
     "tslib": "^2.4.1",
     "typescript": "^5.0.0",
+    "uuid": "^9.0.1",
     "vite": "^5.0.3",
     "vite-node": "^1.3.1",
     "vitest": "^1.2.2"

--- a/apps/server/src/lib/stores/queries.test.ts
+++ b/apps/server/src/lib/stores/queries.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useQuery, init as initQueries } from './queries'
+import { type ViewParams } from './viewParams'
+import { get, Writable, writable } from 'svelte/store'
+import { v4 as uuidv4 } from 'uuid';
+
+// @ts-expect-error - This imported functions are defined in the mock below, but not in the actual file
+import { resetQueryState, mockFetchFn } from '@latitude-data/client'
+import { setViewParam } from './viewParams'
+
+vi.mock('$app/environment', () => {
+  return {
+    browser: true
+  }
+})
+
+type MockQueryState = {
+  queries: Record<string, unknown>
+  forceRefetch: (request: unknown) => Promise<void>
+  fetch: (request: unknown) => Promise<void>
+}
+
+vi.mock('@latitude-data/client', () => {
+  const mockFetchFn = vi.fn(async () => {})
+  const initialQueryState: MockQueryState = {
+    queries: {},
+    forceRefetch: mockFetchFn,
+    fetch: mockFetchFn,
+  }
+  let queryState: Writable<MockQueryState>
+  
+  return {
+    store: {
+      subscribe: vi.fn((subscription) => {
+        return queryState.subscribe(subscription)
+      }),
+      getState: vi.fn(() => get(queryState)),
+      update: vi.fn((updater) => {
+        queryState.update(updater)
+      }),
+    },
+    createQueryKey: (queryPath: string, params: Record<string, unknown>): string => {
+      return queryPath + JSON.stringify(params)
+    },
+    resetQueryState: () => {
+      queryState = writable(initialQueryState)
+      mockFetchFn.mockReset()
+    },
+    mockFetchFn,
+  }
+})
+
+let mockViewParams: Writable<ViewParams>
+
+vi.mock('./viewParams', () => {
+  return {
+    useViewParams: () => mockViewParams,
+    getAllViewParams: vi.fn(() => get(mockViewParams)),
+    setViewParam: vi.fn((key: string, value: unknown) => {
+      mockViewParams.update((params) => {
+        params[key] = value
+        return params
+      })
+    })
+  }
+})
+
+initQueries() // Initialize the queries store. Otherwise the fetch function would never be called
+
+describe('useQuery with reactiveParams', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    resetQueryState()
+    mockViewParams = writable<ViewParams>({})
+  })
+
+  it('should not run the refetch function when reactiveParams is not set', () => {
+    // Subscribe to a query
+    const query = uuidv4()
+    const opts = { reactiveToParams: false }
+    useQuery({ query, opts })
+
+    // The 'fetch' method should be called once when the query is first subscribed
+    expect(mockFetchFn).toHaveBeenCalledTimes(1)
+
+    // Update the viewParams
+    setViewParam('param', 'value')
+    vi.runAllTimers()
+
+    // The 'fetch' method should not have been called again
+    expect(mockFetchFn).toHaveBeenCalledTimes(1)
+  })
+
+  it('should re-run the refetch function each time the parameters change when reactiveParams is set to true', () => {
+    // Subscribe to a query
+    const query = uuidv4()
+    const opts = { reactiveToParams: true }
+    useQuery({ query, opts })
+
+    // The 'fetch' method should be called once when the query is first subscribed
+    expect(mockFetchFn).toHaveBeenCalledTimes(1)
+
+    // Update the viewParams
+    setViewParam('param', 'value1')
+    setViewParam('param', 'value2')
+    setViewParam('param', 'value3')
+    setViewParam('param', 'value4')
+    vi.runAllTimers()
+
+    // The 'fetch' method should have been called the 1 initial time + 4 times when the viewParams were updated
+    expect(mockFetchFn).toHaveBeenCalledTimes(5)
+  })
+
+  it('should re-run the refetch function only when the debounce time has passed when reactiveParams is set to a number', () => {
+    // Subscribe to a query
+    const query = uuidv4()
+    const opts = { reactiveToParams: 100 } // 100ms debounce time
+    useQuery({ query, opts })
+    vi.runAllTimers()
+
+    // The 'fetch' method should be called once when the query is first subscribed
+    expect(mockFetchFn).toHaveBeenCalledTimes(1)
+
+    // Update the viewParams multiple times
+    setViewParam('param', 'value1')
+    setViewParam('param', 'value2')
+    setViewParam('param', 'value3')
+    setViewParam('param', 'value4')
+    vi.runAllTimers()
+
+    // The 'fetch' method should have been called the 1 initial time + 1 time after the debounce time has passed
+    expect(mockFetchFn).toHaveBeenCalledTimes(2)
+  })
+})

--- a/apps/server/src/lib/stores/queries.ts
+++ b/apps/server/src/lib/stores/queries.ts
@@ -159,6 +159,12 @@ export function useQuery({
     }, debounceTime)
 
     useViewParams().subscribe(() => {
+      const newComputedParams = computeQueryParams(inlineParams)
+      const newCoreQueryKey = createKeyForQueryStore(query, newComputedParams)
+      if (debounceTime === 0 || newCoreQueryKey in queryStore.getState().queries) {
+        fetchQueryFromCore({ query, inlineParams })
+        return
+      }
       debouncedRefetch()
     })
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
       '@types/mock-fs':
         specifier: ^4.13.4
         version: 4.13.4
+      '@types/uuid':
+        specifier: ^9.0.8
+        version: 9.0.8
       autoprefixer:
         specifier: ^10.4.17
         version: 10.4.17(postcss@8.4.35)
@@ -129,6 +132,9 @@ importers:
       typescript:
         specifier: ^5.0.0
         version: 5.3.3
+      uuid:
+        specifier: ^9.0.1
+        version: 9.0.1
       vite:
         specifier: ^5.0.3
         version: 5.0.12(@types/node@18.19.15)
@@ -16826,6 +16832,9 @@ packages:
   /sqlite3@5.1.7:
     resolution: {integrity: sha512-GGIyOiFaG+TUra3JIfkI/zGP8yZYLPQ0pl1bH+ODjiX57sPhrLU5sQJn1y9bDKZUFYkX1crlrPfSYt0BKKdkog==}
     requiresBuild: true
+    peerDependenciesMeta:
+      node-gyp:
+        optional: true
     dependencies:
       bindings: 1.5.0
       node-addon-api: 7.1.0


### PR DESCRIPTION
If `reactiveToParams` is active, don't debounce if the results have already been fetched beforehand. Debounce only the actual fetch requests.