### PR TITLE
Feature: use param function on views

### DIFF
--- a/.changeset/flat-cougars-deliver.md
+++ b/.changeset/flat-cougars-deliver.md
@@ -1,0 +1,5 @@
+---
+"@latitude-data/server": minor
+---
+
+New 'param' function to display the value of parameters in a View.

--- a/apps/server/vite.config.ts
+++ b/apps/server/vite.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
       },
       mapping: {
         runQuery: 'import { runQuery } from "$lib/stores/queries"',
+        param: 'import { useViewParam as param } from "$lib/stores/viewParams"',
         input: 'import { input } from "$lib/stores/queries"',
       },
       components: [{ name: './src/lib/autoimports', flat: true }],

--- a/docs/queries/logic/parameters.mdx
+++ b/docs/queries/logic/parameters.mdx
@@ -23,8 +23,6 @@ WHERE id != {param('company_id')} -- This is where the data from Input is insert
 ```
 
 
-<Note>It only works in `.sql` files</Note>
-
 ### Example
 
 1. **Configure the input in our view**


### PR DESCRIPTION
Allow to use a reactive `param('name')` function in the Views.


Usage example:

```jsx
<Row>
  <Text.H1 class="font-bold">Netflix Analysis</Text.H1>
</Row>
<Row>
  <Text.H3 class="font-bold">From {param('start_year')} to {param('end_year')}</Text.H3>
</Row>
<Row>
  <Text.H4>This data app shows titles added to Netflix over the years.</Text.H4>
</Row>
<Row class="mt-4 md:mt-8 gap-4">
  <Input param="start_year" type="number" value="2000" />
  <Input param="end_year" type="number" value="2024" />
</Row>
```
<img width="626" alt="image" src="https://github.com/latitude-dev/latitude/assets/57395395/03d266fe-bc4c-4a68-9ac3-c6e95278f5ab">
