### PR TITLE
Fix: Manage connection lifespan

### DIFF
--- a/.changeset/nine-games-attack.md
+++ b/.changeset/nine-games-attack.md
@@ -1,0 +1,14 @@
+---
+"@latitude-data/clickhouse-connector": patch
+"@latitude-data/databricks-connector": patch
+"@latitude-data/postgresql-connector": patch
+"@latitude-data/athena-connector": patch
+"@latitude-data/duckdb-connector": patch
+"@latitude-data/mssql-connector": patch
+"@latitude-data/mysql-connector": patch
+"@latitude-data/base-connector": patch
+"@latitude-data/cli": patch
+"@latitude-data/server": patch
+---
+
+Manage client connection instance to allow running multiple queries in the same request.

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -17,6 +17,7 @@
     "query": "vite-node scripts/run_query/index.ts"
   },
   "devDependencies": {
+    "@latitude-data/base-connector": "workspace:*",
     "@latitude-data/client": "workspace:*",
     "@latitude-data/eslint-config": "workspace:*",
     "@latitude-data/query_result": "workspace:*",

--- a/apps/server/src/hooks.server.ts
+++ b/apps/server/src/hooks.server.ts
@@ -1,4 +1,7 @@
+import configureShutdown from '$lib/server/shutdown'
 import { Handle } from '@sveltejs/kit'
+
+configureShutdown()
 
 // TODO: Implement CORS origin property in `latitude.json` and use it here
 // this way users are able to configure what domains are allowed to pull data from

--- a/apps/server/src/lib/query_service/find_or_compute.ts
+++ b/apps/server/src/lib/query_service/find_or_compute.ts
@@ -1,7 +1,7 @@
 import findQueryFile from '@latitude-data/query_service'
-import { createConnector } from '@latitude-data/connector-factory'
 import cache from './query_cache'
 import path from 'path'
+import { loadConnector } from '$lib/server/connectorManager'
 
 type Props = {
   query: string
@@ -17,7 +17,7 @@ export default async function findOrCompute({
   force,
 }: Props) {
   const { sourcePath } = await findQueryFile(QUERIES_DIR, query)
-  const connector = createConnector(sourcePath)
+  const connector = loadConnector(sourcePath)
   const { compiledQuery, resolvedParams } = await connector.compileQuery({
     queryPath: computeRelativeQueryPath({ sourcePath, queryPath: query }),
     params: queryParams,

--- a/apps/server/src/lib/server/connectorManager.ts
+++ b/apps/server/src/lib/server/connectorManager.ts
@@ -1,0 +1,21 @@
+import { type BaseConnector } from '@latitude-data/base-connector'
+import { createConnector } from '@latitude-data/connector-factory'
+
+const connectors: Record<string, BaseConnector> = {}
+
+export function loadConnector(sourcePath: string): BaseConnector {
+  if (!connectors[sourcePath]) {
+    connectors[sourcePath] = createConnector(sourcePath)
+  }
+
+  return connectors[sourcePath]
+}
+
+export async function clearConnector(sourcePath: string): Promise<void> {
+  await connectors[sourcePath]?.end()
+  delete connectors[sourcePath]
+}
+
+export async function clearAllConnector(): Promise<void> {
+  await Promise.all(Object.keys(connectors).map(clearConnector))
+}

--- a/apps/server/src/lib/server/shutdown.ts
+++ b/apps/server/src/lib/server/shutdown.ts
@@ -1,0 +1,36 @@
+import { clearAllConnector } from './connectorManager'
+let isListening = false
+
+/**
+ * This module provides mechanisms to gracefully shutdown of the server. A graceful shutdown ensures that the
+ * server terminates its operations in an orderly manner, handling any necessary cleanup tasks before exiting.
+ * Such tasks typically include closing open resources, such as database connections, and performing any other
+ * required state cleanup to prevent data corruption or loss. This is crucial for maintaining data integrity and
+ * system stability, especially in production environments.
+ */
+async function shutdown(): Promise<void> {
+  await clearAllConnector() // Manually close all open database connections
+}
+
+export default function configureShutdownHandler(): void {
+  // Although this function should only be called once, we do not have actual control over
+  // it. Therefore, we we add a guard to prevent multiple listeners from being attached.
+  if (isListening) return
+  isListening = true
+
+  const gracefulShutdown = () => {
+    shutdown()
+      .then(() => {
+        console.log('Server successfully shutdown.')
+      })
+      .catch((err) => {
+        console.error('Error during shutdown:', err)
+      })
+      .finally(() => {
+        process.exit(0)
+      })
+  }
+
+  process.on('SIGINT', gracefulShutdown)
+  process.on('SIGTERM', gracefulShutdown)
+}

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -35,7 +35,7 @@ class CLIConfig {
   public async init(argv: string[]) {
     const args = mri(argv.slice(2))
     this._simulatedPro = args['simulate-pro'] ?? false
-    this.verbose = (args.verbose as boolean | undefined) ?? false
+    this.verbose = args.debug ?? false
   }
 
   public get appDir() {

--- a/packages/connectors/athena/src/index.ts
+++ b/packages/connectors/athena/src/index.ts
@@ -14,14 +14,15 @@ import {
 } from '@latitude-data/base-connector'
 import QueryResult, { DataType, Field } from '@latitude-data/query_result'
 
-interface AthenaQueryClientConfig {
-  client: {
-    region?: string
-    credentials?: {
-      accessKeyId: string
-      secretAccessKey: string
-    }
+type AthenaQueryClientOptions = {
+  region?: string
+  credentials?: {
+    accessKeyId: string
+    secretAccessKey: string
   }
+}
+interface AthenaQueryClientConfig {
+  client: AthenaQueryClientOptions
   database: string
   catalog: string
   workgroup: string
@@ -49,12 +50,17 @@ export class AthenaConnector extends BaseConnector {
   constructor(rootPath: string, connectionParams: ConnectionParams) {
     super(rootPath)
 
-    this.client = new AthenaClient(connectionParams.client)
     this.database = connectionParams.database || this.database
     this.catalog = connectionParams.catalog || this.catalog
     this.workgroup = connectionParams.workgroup || this.workgroup
     this.resultReuseConfiguration =
       connectionParams.resultReuseConfiguration || this.resultReuseConfiguration
+
+    this.client = new AthenaClient(connectionParams.client)
+  }
+
+  async end(): Promise<void> {
+    this.client.destroy()
   }
 
   resolve(value: unknown, _: number): ResolvedParam {

--- a/packages/connectors/base/src/index.ts
+++ b/packages/connectors/base/src/index.ts
@@ -30,36 +30,22 @@ export abstract class BaseConnector {
   protected abstract resolve(value: unknown, index: number): ResolvedParam
 
   protected abstract runQuery(request: CompiledQuery): Promise<QueryResult>
-  protected async connect(): Promise<void> {}
-  protected async disconnect(): Promise<void> {}
+  async end(): Promise<void> {}
 
   async run(request: QueryRequest): Promise<QueryResult> {
-    await this.connect()
-
     const resolvedParams: ResolvedParam[] = []
     const ranQueries: Record<string, QueryResultArray> = {}
     const queriesBeingCompiled: string[] = []
-
-    try {
-      return await this._query({
-        request,
-        resolvedParams,
-        ranQueries,
-        queriesBeingCompiled,
-      })
-    } finally {
-      await this.disconnect()
-    }
+    return await this._query({
+      request,
+      resolvedParams,
+      ranQueries,
+      queriesBeingCompiled,
+    })
   }
 
   async runCompiled(request: CompiledQuery): Promise<QueryResult> {
-    await this.connect()
-
-    try {
-      return await this.runQuery(request)
-    } finally {
-      await this.disconnect()
-    }
+    return await this.runQuery(request)
   }
 
   async compileQuery(

--- a/packages/connectors/clickhouse/src/index.ts
+++ b/packages/connectors/clickhouse/src/index.ts
@@ -9,6 +9,7 @@ import { readFileSync } from 'fs'
 import { ClickHouseSettings, createClient } from '@clickhouse/client'
 import QueryResult, { DataType, Field } from '@latitude-data/query_result'
 import { NodeClickHouseClientConfigOptions } from '@clickhouse/client/dist/config'
+import { NodeClickHouseClient } from '@clickhouse/client/dist/client'
 
 export type TLSOptions = {
   ca_cert: string
@@ -29,7 +30,7 @@ export type ConnectionParams = {
 }
 
 export class ClickHouseConnector extends BaseConnector {
-  private client
+  private client: NodeClickHouseClient
 
   constructor(rootPath: string, connectionParams: ConnectionParams) {
     super(rootPath)
@@ -39,6 +40,10 @@ export class ClickHouseConnector extends BaseConnector {
     } catch (error) {
       throw new ConnectionError((error as Error).message)
     }
+  }
+
+  async end(): Promise<void> {
+    await this.client.close()
   }
 
   resolve(value: unknown, id: number): ResolvedParam {

--- a/packages/connectors/mssql/src/index.ts
+++ b/packages/connectors/mssql/src/index.ts
@@ -23,12 +23,16 @@ export type ConnectionParams = {
 }
 
 export class MssqlConnector extends BaseConnector {
-  private pool
+  private pool: sql.ConnectionPool
 
   constructor(rootPath: string, connectionParams: ConnectionParams) {
     super(rootPath)
 
     this.pool = new sql.ConnectionPool(connectionParams)
+  }
+
+  end(): Promise<void> {
+    return this.pool.close()
   }
 
   resolve(value: unknown, index: number): ResolvedParam {

--- a/packages/connectors/mysql/src/index.test.ts
+++ b/packages/connectors/mysql/src/index.test.ts
@@ -80,7 +80,7 @@ describe('runQuery', () => {
     ).rejects.toThrow('connection error')
   })
 
-  it('releases the connection and ends the pool when connection.query completes', async () => {
+  it('releases the connection when connection.query completes', async () => {
     const connectionMock = {
       query: vi.fn().mockImplementationOnce((_, __, cb) => cb(null, [], [])),
       release: vi.fn(),
@@ -104,6 +104,5 @@ describe('runQuery', () => {
     await connector.runQuery({ sql: 'sql', params: [] })
 
     expect(connectionMock.release).toHaveBeenCalled()
-    expect(poolMock.end).toHaveBeenCalled()
   })
 })

--- a/packages/connectors/postgresql/src/index.ts
+++ b/packages/connectors/postgresql/src/index.ts
@@ -30,11 +30,10 @@ export type ConnectionParams = {
 }
 
 export class PostgresConnector extends BaseConnector {
-  private pool
+  private pool: pg.Pool
 
   constructor(rootPath: string, connectionParams: ConnectionParams) {
     super(rootPath)
-
     this.pool = new Pool(this.buildConnectionParams(connectionParams))
 
     if (connectionParams.schema) {
@@ -42,6 +41,10 @@ export class PostgresConnector extends BaseConnector {
         client.query(`SET search_path TO ${connectionParams.schema}`)
       })
     }
+  }
+
+  end(): Promise<void> {
+    return this.pool.end()
   }
 
   resolve(value: unknown, index: number): ResolvedParam {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
         specifier: ^4.17.21
         version: 4.17.21
     devDependencies:
+      '@latitude-data/base-connector':
+        specifier: workspace:*
+        version: link:../../packages/connectors/base
       '@latitude-data/eslint-config':
         specifier: workspace:*
         version: link:../../tools/eslint-config
@@ -680,6 +683,8 @@ importers:
       puppeteer:
         specifier: ^21.9.0
         version: 21.11.0
+
+  packages/client/webcomponents/loader: {}
 
   packages/connectors/athena:
     dependencies:
@@ -20637,6 +20642,9 @@ packages:
   /sqlite3@5.1.7:
     resolution: {integrity: sha512-GGIyOiFaG+TUra3JIfkI/zGP8yZYLPQ0pl1bH+ODjiX57sPhrLU5sQJn1y9bDKZUFYkX1crlrPfSYt0BKKdkog==}
     requiresBuild: true
+    peerDependenciesMeta:
+      node-gyp:
+        optional: true
     dependencies:
       bindings: 1.5.0
       node-addon-api: 7.1.0


### PR DESCRIPTION
`BaseConnector` is already managing the connector pools lifespan. It runs the `connect` method before running a query, then runs that query and any other one that is included in it, and finally runs the `disconnect` method afterwards.

This allows to keep the `BaseConnector` instance alive whenever we want, without having to worry about having open connections.

Although this is the default behaviour, most connectors do not have any implementation for these `connect` and `disconnect` methods, which they should.