### PR TITLE
Fix: CLI Table cuts off last two results

### DIFF
--- a/.changeset/proud-icons-worry.md
+++ b/.changeset/proud-icons-worry.md
@@ -1,0 +1,5 @@
+---
+"@latitude-data/server": patch
+---
+
+Fix: CLI run command no longer cuts off last 2 results from table

--- a/apps/server/scripts/run_query/result_display.ts
+++ b/apps/server/scripts/run_query/result_display.ts
@@ -105,6 +105,8 @@ export default class QueryDisplay {
       }`,
     )
     const table: Widgets.ListTableElement = listtable({
+      top: 0,
+      bottom: 0,
       keys: true,
       mouse: true,
       border: {


### PR DESCRIPTION
CLI run command always cut off the last two results from the table.

```sql
{@const ids = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]}

{#each ids as i}
  {#if i > 1}UNION ALL{/if}
  SELECT {i} AS id
{/each}
```

Before vs after:
<img src="https://github.com/latitude-dev/latitude/assets/57395395/1ebc47d1-9f61-47df-b85c-737e21d8a012" width=300 />

<img src="https://github.com/latitude-dev/latitude/assets/57395395/f0fe29e7-deab-4e94-9c9c-dea6a887fc65" width=300 />

