### PR TITLE
Fix StencilJS webcomponents build

### DIFF
--- a/.changeset/ninety-penguins-invent.md
+++ b/.changeset/ninety-penguins-invent.md
@@ -1,0 +1,6 @@
+---
+"@latitude-data/webcomponents": minor
+"@latitude-data/react": minor
+---
+
+Fix build of stenciljs when generating react wrapper for latitude-embed

--- a/examples/sample-react/src/app.tsx
+++ b/examples/sample-react/src/app.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import { defineCustomElements } from '@latitude-data/react'
 import { RouterProvider, createRouter } from '@tanstack/react-router'
 import './index.css'
 import { LatitudeProvider } from '@latitude-data/react'
@@ -13,9 +12,6 @@ declare module '@tanstack/react-router' {
     router: typeof router
   }
 }
-
-// Define the custom elements from Latitude React
-defineCustomElements()
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/examples/sample-react/src/examples/Embedding/index.tsx
+++ b/examples/sample-react/src/examples/Embedding/index.tsx
@@ -24,7 +24,7 @@ export default function Embedding() {
   const { headerHeight } = useExample()
   const [ref, { height }] = useMeasure<HTMLDivElement>()
   const topHeight = height + headerHeight
-  const [endYear, setEndYear] = useState(2006)
+  const [endYear, setEndYear] = useState('2006')
 
   const runQuery = useCallback(() => {
     runEmbedViewQuery({ queryPaths: [], force: true })
@@ -64,7 +64,7 @@ export default function Embedding() {
             name='name'
             value={endYear}
             onChange={(e) => {
-              const value = Number(e.target.value)
+              const value = e.target.value
               changeEmbedParams({ end_year: value })
               setEndYear(value)
             }}
@@ -87,12 +87,15 @@ export default function Embedding() {
         <div className='absolute -top-2.5 left-4 px-2 py-0.5 text-xs text-orange-700 uppercase rounded border border-orange-500 bg-white'>Latitude iframe</div>
         {/* FIXME: Types are wrong in generated component */}
         {/* This needs more investigation */}
+
+        {/* Use the URL to this data project. You can run it locally */}
+        {/* https://github.com/latitude-dev/netflix-starwars */}
         <LatitudeEmbed
-          url='http://localhost:3000'
-          params={{ start_year: 2003, end_year: endYear }}
+          url='https://netflix-starwars-black-shadow-3482.fly.dev'
+          params={{ start_year: '2003', end_year: endYear }}
           onParamsChanged={(event: CustomEvent<EmbeddingEventData<EmbeddingEvent.ParamsChanged>>) => {
             const params = event.detail.params
-            const newEndYear = params.end_year as number
+            const newEndYear = params.end_year as string
             if (endYear === newEndYear) return
 
             setEndYear(newEndYear)

--- a/packages/client/react/rollup.config.mjs
+++ b/packages/client/react/rollup.config.mjs
@@ -3,9 +3,8 @@ import typescript from '@rollup/plugin-typescript'
 const EXTERNAL_DEPENDENCIES = [
   '@latitude-data/client',
   '@latitude-data/query_result',
-  '@latitude-data/webcomponents',
-  '@latitude-data/webcomponents/loader',
   '@latitude-data/embedding',
+  '@latitude-data/webcomponents/dist/components/latitude-embed.js',
   '@tanstack/react-query',
   'react/jsx-runtime',
   'react-dom',

--- a/packages/client/react/src/index.ts
+++ b/packages/client/react/src/index.ts
@@ -1,6 +1,5 @@
 export * from './data/LatitudeProvider'
 export * from './data/useQuery'
-export { defineCustomElements } from '@latitude-data/webcomponents/loader'
 export type { QueryResultPayload } from '@latitude-data/query_result'
 
 export * from '@latitude-data/embedding'

--- a/packages/client/react/src/webcomponents/index.ts
+++ b/packages/client/react/src/webcomponents/index.ts
@@ -3,8 +3,8 @@
 /* auto-generated react proxies */
 import { createReactComponent } from './react-component-lib';
 
-import type { JSX } from '@latitude-data/webcomponents';
+import type { JSX } from '@latitude-data/webcomponents/dist/components';
 
+import { defineCustomElement as defineLatitudeEmbed } from '@latitude-data/webcomponents/dist/components/latitude-embed.js';
 
-
-export const LatitudeEmbed = /*@__PURE__*/createReactComponent<JSX.LatitudeEmbed, HTMLLatitudeEmbedElement>('latitude-embed');
+export const LatitudeEmbed = /*@__PURE__*/createReactComponent<JSX.LatitudeEmbed, HTMLLatitudeEmbedElement>('latitude-embed', undefined, undefined, defineLatitudeEmbed);

--- a/packages/client/webcomponents/package.json
+++ b/packages/client/webcomponents/package.json
@@ -7,12 +7,6 @@
     "type": "git",
     "url": "https://github.com/latitude-dev/latitude.git"
   },
-  "main": "dist/index.cjs.js",
-  "module": "dist/index.js",
-  "types": "dist/types/components.d.ts",
-  "collection": "dist/collection/collection-manifest.json",
-  "collection:main": "dist/collection/index.js",
-  "unpkg": "dist/webcomponents/webcomponents.esm.js",
   "scripts": {
     "dev": "stencil build --watch",
     "build": "stencil build",
@@ -22,32 +16,28 @@
     "test:watch": "stencil test --spec --watchAll",
     "generate": "stencil generate"
   },
+  "main": "./dist/components/index.js",
+  "module": "./dist/components/index.js",
+  "types": "./dist/components/index.d.ts",
   "exports": {
-    ".": {
-      "import": "./dist/webcomponents/webcomponents.esm.js",
-      "require": "./dist/webcomponents/webcomponents.cjs.js"
+    "./dist/components": {
+      "import": "./dist/components/index.js",
+      "types": "./dist/components/index.d.ts"
     },
-    "./loader": {
-      "import": "./loader/index.js",
-      "types": "./loader/index.d.ts"
-    },
-    "./latitude-embed": {
+    "./dist/components/latitude-embed.js": {
       "import": "./dist/components/latitude-embed.js",
-      "types": "./dist/components/latitude-embed.d.ts"
+      "types": "./dist/types/components.d.ts"
     }
   },
-  "files": [
-    "dist/",
-    "loader/"
-  ],
+  "files": ["dist/"],
   "dependencies": {
     "@latitude-data/embedding": "workspace:*"
   },
   "devDependencies": {
-    "@stencil/core": "^4.7.0",
-    "@stencil/react-output-target": "^0.5.3",
     "@types/jest": "^29.5.6",
     "@types/node": "^16.18.11",
+    "@stencil/core": "^4.7.0",
+    "@stencil/react-output-target": "^0.5.3",
     "jest": "^29.7.0",
     "jest-cli": "^29.7.0",
     "prettier": "^3.1.1",

--- a/packages/client/webcomponents/src/index.ts
+++ b/packages/client/webcomponents/src/index.ts
@@ -7,3 +7,5 @@
  * DO NOT use this file to export your components. Instead, use the recommended approaches
  * to consume components of this package as outlined in the `README.md`.
  */
+
+export type * from './components.d.ts'

--- a/packages/client/webcomponents/stencil.config.ts
+++ b/packages/client/webcomponents/stencil.config.ts
@@ -4,16 +4,17 @@ import { reactOutputTarget } from '@stencil/react-output-target'
 export const config: Config = {
   namespace: 'webcomponents',
   outputTargets: [
-    { type: 'dist', esmLoaderPath: '../loader' },
+    { type: 'docs-readme' },
     {
       type: 'dist-custom-elements',
-      customElementsExportBehavior: 'auto-define-custom-elements',
-      externalRuntime: false,
+      customElementsExportBehavior: 'single-export-module',
+      generateTypeDeclarations: true,
     },
-    { type: 'docs-readme' },
     reactOutputTarget({
       componentCorePackage: '@latitude-data/webcomponents',
       proxiesFile: '../react/src/webcomponents/index.ts',
+      customElementsDir: 'dist/components',
+      includeImportCustomElements: true,
     }),
   ],
   testing: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -706,8 +706,6 @@ importers:
         specifier: ^21.9.0
         version: 21.11.0
 
-  packages/client/webcomponents/loader: {}
-
   packages/connectors/athena:
     dependencies:
       '@aws-sdk/client-athena':


### PR DESCRIPTION
# What?
We use StencilJS in our @latitude-data/webcomponents. StencilJS help use author webcomponents and a thin wrapper in React. But in the future we can add support for Vue or Svelte. The problem was that I develop the iframe integration and it worked in developent but when I deployed a production react example using our `LatitudeEmbed` component I realized build was broken. This pr try to produce a valid Stencil + React build for our component. We use `dist-custom-elements` as StencilJS target to be use together with the React wrapper generated by StencilJS