### PR TITLE
Fix missing `defineCustomComponents` from @latitude-data/webcomponents

### DIFF
--- a/.changeset/smooth-monkeys-kick.md
+++ b/.changeset/smooth-monkeys-kick.md
@@ -1,0 +1,6 @@
+---
+"@latitude-data/webcomponents": minor
+"@latitude-data/react": minor
+---
+
+Fix missing defineCustomComponents export in @latitude-data/react

--- a/examples/sample-react/src/app.tsx
+++ b/examples/sample-react/src/app.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { RouterProvider, createRouter } from '@tanstack/react-router'
 import './index.css'
-import { LatitudeProvider } from '@latitude-data/react'
+import { LatitudeProvider, defineCustomElements } from '@latitude-data/react'
 
 import { routeTree } from './routeTree.gen'
 const router = createRouter({ routeTree })
@@ -12,6 +12,8 @@ declare module '@tanstack/react-router' {
     router: typeof router
   }
 }
+
+defineCustomElements(window)
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/packages/client/react/rollup.config.mjs
+++ b/packages/client/react/rollup.config.mjs
@@ -4,6 +4,7 @@ const EXTERNAL_DEPENDENCIES = [
   '@latitude-data/client',
   '@latitude-data/query_result',
   '@latitude-data/embedding',
+  '@latitude-data/webcomponents/dist/loader',
   '@latitude-data/webcomponents/dist/components/latitude-embed.js',
   '@tanstack/react-query',
   'react/jsx-runtime',

--- a/packages/client/react/src/index.ts
+++ b/packages/client/react/src/index.ts
@@ -3,4 +3,5 @@ export * from './data/useQuery'
 export type { QueryResultPayload } from '@latitude-data/query_result'
 
 export * from '@latitude-data/embedding'
+export { defineCustomElements } from '@latitude-data/webcomponents/dist/loader'
 export * from './webcomponents'

--- a/packages/client/webcomponents/package.json
+++ b/packages/client/webcomponents/package.json
@@ -16,10 +16,17 @@
     "test:watch": "stencil test --spec --watchAll",
     "generate": "stencil generate"
   },
-  "main": "./dist/components/index.js",
-  "module": "./dist/components/index.js",
+  "main": "./dist/index.cjs.js",
+  "module": "./dist/index.js",
+  "collection": "dist/collection/collection-manifest.json",
+  "collection:main": "dist/collection/index.js",
+  "unpkg": "dist/webcomponents/webcomponents.esm.js",
   "types": "./dist/components/index.d.ts",
   "exports": {
+    "./dist/loader": {
+      "import": "./dist/loader/index.js",
+      "types": "./dist/loader/index.d.ts"
+    },
     "./dist/components": {
       "import": "./dist/components/index.js",
       "types": "./dist/components/index.d.ts"

--- a/packages/client/webcomponents/stencil.config.ts
+++ b/packages/client/webcomponents/stencil.config.ts
@@ -5,6 +5,7 @@ export const config: Config = {
   namespace: 'webcomponents',
   outputTargets: [
     { type: 'docs-readme' },
+    { type: 'dist' },
     {
       type: 'dist-custom-elements',
       customElementsExportBehavior: 'single-export-module',


### PR DESCRIPTION
# What?
Everything build ok in development and build + preview but when testing the full story deploying example react app to Vercel build fail saying "has no exported member 'defineCustomElements'"
I hope this fix the problem

<img width="1235" alt="image" src="https://github.com/latitude-dev/latitude/assets/49499/b4a536bb-598f-4ada-8225-9a829d4579c3">
