### PR TITLE
Fix Error: [vite]: Rollup failed to resolve import "@stencil/core/internal/client"

### DIFF
--- a/.changeset/moody-phones-swim.md
+++ b/.changeset/moody-phones-swim.md
@@ -1,0 +1,5 @@
+---
+"@latitude-data/react": minor
+---
+
+Missing pnpm-lock.json line

--- a/packages/client/react/package.json
+++ b/packages/client/react/package.json
@@ -17,10 +17,10 @@
   "types": "dist/index.d.ts",
   "dependencies": {
     "@latitude-data/client": "workspace:*",
-    "@latitude-data/webcomponents": "workspace:*",
+    "@latitude-data/embedding": "workspace:*",
     "@latitude-data/query_result": "workspace:^",
-    "@tanstack/react-query": "^5.28.14",
-    "@latitude-data/embedding": "workspace:*"
+    "@latitude-data/webcomponents": "workspace:*",
+    "@tanstack/react-query": "^5.28.14"
   },
   "peerDependencies": {
     "react": "^17.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -706,6 +706,8 @@ importers:
         specifier: ^21.9.0
         version: 21.11.0
 
+  packages/client/webcomponents/dist/loader: {}
+
   packages/connectors/athena:
     dependencies:
       '@aws-sdk/client-athena':


### PR DESCRIPTION
# What?
I wasn't able to deploy to Vercel example react app with `@latitude-data/webcomponents` + `@latitude-data/react` packages. That means something is still broken

The error I see in Vercel logs is this
<img width="1308" alt="image" src="https://github.com/latitude-dev/latitude/assets/49499/ea252ad0-8197-4569-847c-c3dff489199d">


This is just a quick test but I need to do a full release to test it from npm. I don't think this is going to fix it because is just adding a missing line in the `pnpm-lock.json` file but it worth a try


## Next try
If this doesn't work my next idea is to include as dependency `@stencil/core` in `@latitude-data/react` package. Apparently Stencil is used at runtime. Which kind of makes sense but I didn't expected.