### PR TITLE
Static files support for views

### DIFF
--- a/.changeset/lemon-ligers-raise.md
+++ b/.changeset/lemon-ligers-raise.md
@@ -1,0 +1,6 @@
+---
+"@latitude-data/cli": minor
+"@latitude-data/server": minor
+---
+
+Support for static files in views. Just add any file inside the `views` folder, and they will be accessible in your web app.

--- a/apps/server/.gitignore
+++ b/apps/server/.gitignore
@@ -7,7 +7,7 @@
 /package
 node_modules
 /queries
-static/latitude
+static
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 
@@ -17,3 +17,4 @@ src/routes/*
 !src/routes/api/
 !src/routes/+layout.svelte
 !src/routes/+layout.server.ts
+!src/routes/+layout.ts

--- a/apps/server/plugins/queriesWatcher.ts
+++ b/apps/server/plugins/queriesWatcher.ts
@@ -8,7 +8,7 @@ declare module 'vite/types/customEvent' {
 }
 
 export default function watchQueriesPlugin() {
-  const queriesPath = path.resolve(__dirname, '../static/latitude/queries')
+  const queriesPath = path.resolve(__dirname, '../static/.latitude/queries')
   return {
     name: 'latitude-queries-watcher',
     enforce: 'post',

--- a/apps/server/src/lib/query_service/find_or_compute.ts
+++ b/apps/server/src/lib/query_service/find_or_compute.ts
@@ -9,7 +9,7 @@ type Props = {
   force: boolean
 }
 
-export const QUERIES_DIR = 'static/latitude/queries'
+export const QUERIES_DIR = 'static/.latitude/queries'
 
 export default async function findOrCompute({
   query,
@@ -45,14 +45,14 @@ export default async function findOrCompute({
 }
 
 export function computeRelativeQueryPath({
-  sourcePath, // /static/latitude/queries/folder/source.yml
+  sourcePath, // /static/.latitude/queries/folder/source.yml
   queryPath, // folder/query.sql
 }: {
   sourcePath: string
   queryPath: string
 }) {
   const base = path
-    .dirname(sourcePath) // /static/latitude/queries/folder
+    .dirname(sourcePath) // /static/.latitude/queries/folder
     .slice(sourcePath.indexOf(QUERIES_DIR) + QUERIES_DIR.length + 1) // folder
 
   if (!base) return queryPath

--- a/apps/server/src/routes/+layout.ts
+++ b/apps/server/src/routes/+layout.ts
@@ -1,0 +1,1 @@
+export const trailingSlash = 'always'

--- a/docs/views/basics/what-are-views.mdx
+++ b/docs/views/basics/what-are-views.mdx
@@ -19,6 +19,9 @@ If you have a file named `views/about.html`, it won't be accessible because we o
 
 If you have both a file and a directory with the same name, the framework will throw an error.
 
+## Static files and assets
+Every file in the `views` directory is publicly accessible. This means that you can use them to serve static files and assets like images, CSS, and JavaScript files. For example, if you have an image called `logo.png` in the `views` directory, you can access it at `/logo.png`.
+
 ## Next steps
 
 Now that you know how to use views, you can start creating views for your data apps. To learn more about how to use layouts to display your data, check out the [Layout docs](/views/basics/layout).

--- a/packages/cli/src/lib/sync/index.ts
+++ b/packages/cli/src/lib/sync/index.ts
@@ -1,6 +1,7 @@
 import syncDependencies from './syncDependencies'
 import syncDotenv from './syncDotenv'
 import syncQueries from './syncQueries'
+import syncStaticFiles from './syncStaticFiles'
 import syncViews from './syncViews'
 
 export default function sync(
@@ -8,6 +9,7 @@ export default function sync(
 ) {
   return Promise.all([
     syncViews({ watch }),
+    syncStaticFiles({ watch }),
     syncDotenv({ watch }),
     syncQueries({ watch }),
     syncDependencies({ watch }),

--- a/packages/cli/src/lib/sync/syncQueries/index.ts
+++ b/packages/cli/src/lib/sync/syncQueries/index.ts
@@ -25,7 +25,7 @@ export default async function syncQueries({
     rootDir,
     APP_FOLDER,
     'static',
-    'latitude',
+    '.latitude',
     'queries',
   )
 

--- a/packages/cli/src/lib/sync/syncStaticFiles/index.test.ts
+++ b/packages/cli/src/lib/sync/syncStaticFiles/index.test.ts
@@ -1,0 +1,71 @@
+// syncStaticFiles.test.ts
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { syncStaticFilesFn } from '.' // Adjust this path to the actual path of your module
+import syncFiles from '../shared/syncFiles'
+
+vi.mock('../shared/syncFiles', () => ({
+  default: vi.fn(),
+}))
+
+describe('syncStaticFiles function', () => {
+  beforeEach(() => {
+    // @ts-expect-error mock
+    ;(syncFiles as vi.Mock).mockClear()
+  })
+
+  it('correctly handles "add" type operation by syncing new file', () => {
+    const rootDir = '/test'
+    const destinationDir = '/test/static'
+
+    // Make the syncStaticFilesFn function ready for tests
+    const handler = syncStaticFilesFn({ rootDir, destinationDir })
+
+    const srcPath = `${rootDir}/views/example/funny_cat.png`
+    const type = 'add'
+
+    // Perform the operation as handled during 'add'
+    handler(srcPath, type, true)
+
+    const expectedDestPath = '/test/static/example/funny_cat.png'
+
+    expect(syncFiles).toHaveBeenCalledWith(
+      expect.objectContaining({
+        srcPath: srcPath,
+        destPath: expectedDestPath,
+        relativePath: 'example/funny_cat.png',
+        type: 'add',
+        ready: true,
+      }),
+    )
+  })
+
+  it('correctly handles "unlink" type operation by removing a synced file', () => {
+    const rootDir = '/test'
+    const destinationDir = '/test/static'
+
+    const handler = syncStaticFilesFn({ rootDir, destinationDir })
+
+    const srcPathBefore = `${rootDir}/views/example/funny_cat.png`
+
+    // Simulate adding a file before testing unlink
+    handler(srcPathBefore, 'add', true)
+
+    const srcPath = `${rootDir}/views/example/funny_cat.png`
+    const type = 'unlink'
+
+    // Perform the operation as handled during 'unlink'
+    handler(srcPath, type, true)
+
+    const expectedDestPath = '/test/static/example/funny_cat.png'
+
+    expect(syncFiles).toHaveBeenCalledWith(
+      expect.objectContaining({
+        srcPath: srcPath,
+        destPath: expectedDestPath,
+        relativePath: 'example/funny_cat.png',
+        type: 'unlink',
+        ready: true,
+      }),
+    )
+  })
+})


### PR DESCRIPTION
ALL files inside `views` that are not `html` files will be copied to the `static` directory in the app folder. The only exception are hidden files and directories (starting with a dot).

We were using a `static/latitude` folder for the queries, but since it can now conflict with the user's view files, I changed it to `static/.latitude`, since hidden directories are not copied.