### PR TITLE
Fix bundle error when deploying React example app

### DIFF
--- a/.changeset/hot-olives-double.md
+++ b/.changeset/hot-olives-double.md
@@ -1,0 +1,5 @@
+---
+"@latitude-data/webcomponents": minor
+---
+
+Ship latitude-embed webcomponent with @stencil/core runtime

--- a/packages/client/webcomponents/stencil.config.ts
+++ b/packages/client/webcomponents/stencil.config.ts
@@ -1,6 +1,12 @@
 import { Config } from '@stencil/core'
 import { reactOutputTarget } from '@stencil/react-output-target'
 
+// NOTE: `externalRuntime: false` why?
+// Docs: https://stenciljs.com/docs/custom-elements#externalruntime
+// This compile in this package `@stencil/core`. Other option would be
+// to do it in `@latitude-data/react` by requiring as dependency `@stencil/core`
+// But for now because we only have one component I think is fine to ship it here.
+// so it has the runtime
 export const config: Config = {
   namespace: 'webcomponents',
   outputTargets: [
@@ -10,6 +16,7 @@ export const config: Config = {
       type: 'dist-custom-elements',
       customElementsExportBehavior: 'single-export-module',
       generateTypeDeclarations: true,
+      externalRuntime: false,
     },
     reactOutputTarget({
       componentCorePackage: '@latitude-data/webcomponents',


### PR DESCRIPTION
# What?
When I deploy example react app using published packages `@latitude-data/react` the building of the app fails saying "Error: [vite]: Rollup failed to resolve import "@stencil/core/internal/client" from". Acording to Stencil Docs: https://stenciljs.com/docs/custom-elements#externalruntime You can ship your component with stencil runtime. This is what I'm trying here

<img width="1294" alt="image" src="https://github.com/latitude-dev/latitude/assets/49499/cc7339fe-444d-4a5e-9e24-4b7dfde1b378">
