### PR TITLE
Use different event in embedding when the URL param change from inside the view

### DIFF
--- a/.changeset/wild-eggs-drive.md
+++ b/.changeset/wild-eggs-drive.md
@@ -1,0 +1,6 @@
+---
+"@latitude-data/webcomponents": patch
+"@latitude-data/embedding": patch
+---
+
+Fix infinite loop when changing an input field. Use different event in embedding when url param is changed from inside view

--- a/apps/server/src/lib/iframeEmbedding.ts
+++ b/apps/server/src/lib/iframeEmbedding.ts
@@ -11,7 +11,7 @@ export function initIframeCommunication({
   allowedOrigins: string[]
 }) {
   iframe.registerAllowedOrigins(allowedOrigins)
-  iframe.onParamsChanged = (data) => {
+  iframe.onParamsRequestChange = (data) => {
     setViewParams(data.params)
   }
   iframe.onRun = (data) => {

--- a/packages/client/webcomponents/src/components/latitude-embed/latitude-embed.tsx
+++ b/packages/client/webcomponents/src/components/latitude-embed/latitude-embed.tsx
@@ -67,9 +67,9 @@ export class LatitudeEmbed {
     })
   }
 
-  @Listen('latitude-params-changed', { target: 'document' })
+  @Listen('latitude-change-param-request', { target: 'document' })
   paramsChangedHander(
-    event: CustomEvent<EmbeddingEventData<EmbeddingEvent.Run>>,
+    event: CustomEvent<EmbeddingEventData<EmbeddingEvent.ChangeParamRequest>>,
   ) {
     this.iframe.contentWindow.postMessage(event.detail, {
       targetOrigin: this.queryOrigin,

--- a/packages/embedding/src/iframe-messages.ts
+++ b/packages/embedding/src/iframe-messages.ts
@@ -12,7 +12,7 @@ export default class IframeMessages {
   allowedOrigins: string[] = []
   private _onRun: MessageHandlerFn<EmbeddingEvent.Run> | undefined
   private _onParamsChanged:
-    | MessageHandlerFn<EmbeddingEvent.ParamsChanged>
+    | MessageHandlerFn<EmbeddingEvent.ChangeParamRequest>
     | undefined
   private _onCustomEvent: MessageHandlerFn<EmbeddingEvent.Custom> | undefined
 
@@ -29,7 +29,9 @@ export default class IframeMessages {
     this._onRun = handler
   }
 
-  set onParamsChanged(handler: MessageHandlerFn<EmbeddingEvent.ParamsChanged>) {
+  set onParamsRequestChange(
+    handler: MessageHandlerFn<EmbeddingEvent.ChangeParamRequest>,
+  ) {
     if (this._onParamsChanged) return
 
     this._onParamsChanged = handler
@@ -52,7 +54,7 @@ export default class IframeMessages {
         case EmbeddingEvent.Run:
           this._onRun?.(event.data)
           break
-        case EmbeddingEvent.ParamsChanged:
+        case EmbeddingEvent.ChangeParamRequest:
           this._onParamsChanged?.(event.data)
           break
         case EmbeddingEvent.Custom:

--- a/packages/embedding/src/index.ts
+++ b/packages/embedding/src/index.ts
@@ -20,7 +20,7 @@ export function triggerCustomEvent(data: unknown) {
 }
 
 export function changeEmbedParams(params: ParamsChangedEventData) {
-  triggerEvent(EmbeddingEvent.ParamsChanged, { params })
+  triggerEvent(EmbeddingEvent.ChangeParamRequest, { params })
 }
 
 export const iframe = new IframeMessages()

--- a/packages/embedding/src/types.ts
+++ b/packages/embedding/src/types.ts
@@ -1,5 +1,6 @@
 export enum EmbeddingEvent {
   Run = 'latitude-run',
+  ChangeParamRequest = 'latitude-change-param-request',
   ParamsChanged = 'latitude-params-changed',
   Custom = 'latitude-custom',
 }
@@ -21,6 +22,8 @@ export type EmbeddingEventData<T extends EmbeddingEvent> =
     ? { type: T } & RunEventData
     : T extends EmbeddingEvent.ParamsChanged
       ? { type: T; params: ParamsChangedEventData }
-      : T extends EmbeddingEvent.Custom
-        ? { type: T; data: unknown }
-        : never
+      : T extends EmbeddingEvent.ChangeParamRequest
+        ? { type: T; params: ParamsChangedEventData }
+        : T extends EmbeddingEvent.Custom
+          ? { type: T; data: unknown }
+          : never


### PR DESCRIPTION
# What?
We were using the same event name when the param is changed from react host app than when is changed from inside view and this was causing an infinite loop 💀 