### PR TITLE
Fix: chokidar is not ignoring correctly

### DIFF
--- a/packages/cli/src/lib/sync/syncViews/index.ts
+++ b/packages/cli/src/lib/sync/syncViews/index.ts
@@ -25,9 +25,7 @@ export default async function syncViews({
   const syncFn = syncFnFactory({ rootDir, destinationDir })
 
   if (watch) {
-    await watcher(viewsDir, syncFn, {
-      ignored: IGNORED_FILES_REGEX,
-    })
+    await watcher(viewsDir, syncFn)
   } else {
     syncDirectory(viewsDir, syncFn)
   }


### PR DESCRIPTION
For some reason, using the regex with chokidar's `ignored` tag is making it ignore all file changes. (The regular expression is `/^(?!.*index\.html$).*$/`, where it should match any file except for `index.html` files)

We instantiate the `watcher` like this:
```ts
await watcher(viewsDir, syncFn, {
  ignored: IGNORED_FILES_REGEX,
})
```

and the `syncFn` has this at the start:
```ts
if (IGNORED_FILES_REGEX.test(relativeSrcPath)) return
```

It should just do the same, so it should not be needed. However, with the ignored tag in the watcher, no files at all are triggering the syncFn. With that tag ignored, every file change does trigger de function, but then it is correctly filtered by the regex. 

Any idea why is it working when manually filtering but not when used as a chokidar option?

Also, chokidar is then instantiated like this:
```
chokidar.watch(dir, { ignored, persistent })
```