### PR TITLE
Feature: See compiled queries from CLI

### DIFF
--- a/.changeset/silly-beers-lick.md
+++ b/.changeset/silly-beers-lick.md
@@ -1,0 +1,6 @@
+---
+"@latitude-data/cli": minor
+"@latitude-data/server": minor
+---
+
+Feature: CLI run command now allows using a --debug tag to see the compiled query

--- a/docs/guides/development/latitude-cli.mdx
+++ b/docs/guides/development/latitude-cli.mdx
@@ -66,3 +66,11 @@ latitude run sample --param name=Latitude --param id=1
 ```
 
 Now, when building the query with the parameters, the `name` and `id` parameters will receive the values `Latitude` and `1`, respectively.
+
+### Debugging queries
+
+You can use the `--debug` flag to display the actual query that would be sent to your database, without actually running it. For example:
+
+```bash
+latitude run sample --debug
+```

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -18,7 +18,7 @@ initSentry()
 const CLI = sade('latitude')
 
 CLI.version(process.env.PACKAGE_VERSION ?? 'development')
-  .option('--debug', 'Enables verbose console logs')
+  .option('--verbose', 'Enables verbose console logs')
   .option('--simulate-pro', 'Enable pro mode in development')
 
 if (process.env.NODE_ENV === 'development') {
@@ -63,6 +63,7 @@ CLI.command('dev')
 CLI.command('run <query_name>')
   .describe('Run a query from the Latitude app.')
   .option('--watch', 'Re-run the query each time the query file changes')
+  .option('--debug', 'Instead of running the query, print the generated SQL')
   .option(
     '--param',
     'Add a parameter to the query. Use the format --param <name>=<value>',

--- a/packages/cli/src/commands/run/index.ts
+++ b/packages/cli/src/commands/run/index.ts
@@ -7,9 +7,14 @@ import tracked from '$src/lib/decorators/tracked'
 
 async function run(
   queryName: string,
-  opts?: { param: string[] | string | undefined; watch: boolean },
+  opts?: {
+    param: string[] | string | undefined
+    watch: boolean
+    debug: boolean
+  },
 ) {
   const watch = opts?.watch || false
+  const debug = opts?.debug || false
 
   await syncQueries({ watch })
 
@@ -17,8 +22,9 @@ async function run(
     'run',
     'query',
     queryName,
-    watch ? 'true' : 'false',
     JSON.stringify(buildParams(opts?.param || [])),
+    watch ? 'true' : 'false',
+    debug ? 'true' : 'false',
   ].filter(Boolean)
 
   return spawn(

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -35,7 +35,7 @@ class CLIConfig {
   public async init(argv: string[]) {
     const args = mri(argv.slice(2))
     this._simulatedPro = args['simulate-pro'] ?? false
-    this.verbose = args.debug ?? false
+    this.verbose = args.verbose ?? false
   }
 
   public get appDir() {

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -11,6 +11,6 @@ export type OnErrorFn = (_args: OnErrorProps) => void
 
 export type CommonCLIArgs = {
   folder?: string
-  debug?: boolean
+  verbose?: boolean
   'simulate-pro'?: boolean
 }

--- a/packages/cli/tests/e2e/dev.cjs
+++ b/packages/cli/tests/e2e/dev.cjs
@@ -7,7 +7,7 @@ function dev () {
     'dev',
     '--open',
     'false',
-    '--debug'
+    '--verbose'
   ], {
     cwd: './test-project',
   })

--- a/packages/cli/tests/e2e/start.cjs
+++ b/packages/cli/tests/e2e/start.cjs
@@ -21,7 +21,7 @@ const spawned = spawn('node', [
   'test-project',
   '--template',
   'default',
-  '--debug'
+  '--verbose'
 ])
 
 spawned.stdout.pipe(process.stdout)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -706,8 +706,6 @@ importers:
         specifier: ^21.9.0
         version: 21.11.0
 
-  packages/client/webcomponents/dist/loader: {}
-
   packages/connectors/athena:
     dependencies:
       '@aws-sdk/client-athena':


### PR DESCRIPTION
Added a `--debug` flag to the `latitude run` command to see the compiled query without actually running it.

Also, all other `--debug` flags from the CLI, which allowed to print console logs, have been been renamed to `--verbose`.