### PR TITLE
Fix LATITUDE-DATA-CLI-7 avoid failing CLI build when no views folder

### DIFF
--- a/.changeset/twelve-parents-fold.md
+++ b/.changeset/twelve-parents-fold.md
@@ -1,0 +1,5 @@
+---
+"@latitude-data/cli": minor
+---
+
+Fix CLI build command failing when views folder doesn't exists

--- a/packages/cli/src/lib/sync/syncStaticFiles/index.ts
+++ b/packages/cli/src/lib/sync/syncStaticFiles/index.ts
@@ -1,10 +1,11 @@
-import fs, { rmSync } from 'fs'
+import { rmSync } from 'fs'
 import path from 'path'
 import syncFiles from '../shared/syncFiles'
 import { APP_FOLDER } from '$src/commands/constants'
 import watcher from '../shared/watcher'
 import { onExit } from '$src/utils'
 import config from '$src/config'
+import { syncDirectory } from '$src/lib/sync/syncViews'
 
 function getStaticFilesFolderPath(cwd: string): string {
   return path.join(cwd, APP_FOLDER, 'static')
@@ -61,20 +62,6 @@ export function syncStaticFilesFn({
 
     syncFiles({ srcPath, relativePath, destPath, type, ready })
   }
-}
-
-export const syncDirectory = (directory: string, syncFn: Function): void => {
-  fs.readdirSync(directory).forEach((file: string) => {
-    const srcPath = path.join(directory, file)
-
-    // Check if the srcPath is a directory, and recursively call syncDirectory if it is
-    if (fs.statSync(srcPath).isDirectory()) {
-      syncDirectory(srcPath, syncFn)
-    } else {
-      // It's a file, perform the synchronization operation
-      syncFn(srcPath, 'add', true)
-    }
-  })
 }
 
 const clearFiles = (watch: boolean) => () => {

--- a/packages/cli/src/lib/sync/syncViews/index.ts
+++ b/packages/cli/src/lib/sync/syncViews/index.ts
@@ -14,6 +14,56 @@ const copiedFiles = new Set<string>()
 
 const IGNORED_FILES_REGEX = /^(?!.*index\.html$).*$/ // ignore all files except index.html
 
+const clearFiles = (watch: boolean) => () => {
+  if (!watch) return
+
+  for (const copiedFile of copiedFiles) {
+    try {
+      rmSync(copiedFile, { recursive: true })
+    } catch (e) {
+      // do nothing
+    }
+  }
+}
+
+export const syncFnFactory =
+  ({ rootDir, destinationDir }: { rootDir: string; destinationDir: string }) =>
+  (srcPath: string, type: 'add' | 'change' | 'unlink', ready: boolean) => {
+    if (!fs.existsSync(rootDir)) return
+
+    const relativeSrcPath = path
+      .relative(rootDir, srcPath)
+      .replace(/^views/, '')
+
+    if (IGNORED_FILES_REGEX.test(relativeSrcPath)) return
+
+    const relativePath = relativeSrcPath.replace(/[^/]*$/, '+page.svelte')
+    const destPath = path.join(destinationDir, relativePath)
+
+    if (type === 'add' || type === 'change') {
+      copiedFiles.add(destPath)
+    } else if (type === 'unlink') {
+      copiedFiles.delete(destPath)
+    }
+
+    syncFiles({ srcPath, relativePath, destPath, type, ready })
+  }
+
+export const syncDirectory = (directory: string, syncFn: Function): void => {
+  if (!fs.existsSync(directory)) return
+
+  fs.readdirSync(directory).forEach((file: string) => {
+    const srcPath = path.join(directory, file)
+
+    if (fs.statSync(srcPath).isDirectory()) {
+      syncDirectory(srcPath, syncFn)
+    } else {
+      // It's a file, perform the synchronization operation
+      syncFn(srcPath, 'add', true)
+    }
+  })
+}
+
 export default async function syncViews({
   watch = false,
 }: {
@@ -31,49 +81,4 @@ export default async function syncViews({
   }
 
   onExit(clearFiles(watch))
-}
-
-export const syncFnFactory =
-  ({ rootDir, destinationDir }: { rootDir: string; destinationDir: string }) =>
-  (srcPath: string, type: 'add' | 'change' | 'unlink', ready: boolean) => {
-    const relativeSrcPath = path
-      .relative(rootDir, srcPath)
-      .replace(/^views/, '')
-    if (IGNORED_FILES_REGEX.test(relativeSrcPath)) return
-    const relativePath = relativeSrcPath.replace(/[^/]*$/, '+page.svelte')
-    const destPath = path.join(destinationDir, relativePath)
-
-    if (type === 'add' || type === 'change') {
-      copiedFiles.add(destPath)
-    } else if (type === 'unlink') {
-      copiedFiles.delete(destPath)
-    }
-
-    syncFiles({ srcPath, relativePath, destPath, type, ready })
-  }
-
-export const syncDirectory = (directory: string, syncFn: Function): void => {
-  fs.readdirSync(directory).forEach((file: string) => {
-    const srcPath = path.join(directory, file)
-
-    // Check if the srcPath is a directory, and recursively call syncDirectory if it is
-    if (fs.statSync(srcPath).isDirectory()) {
-      syncDirectory(srcPath, syncFn)
-    } else {
-      // It's a file, perform the synchronization operation
-      syncFn(srcPath, 'add', true)
-    }
-  })
-}
-
-const clearFiles = (watch: boolean) => () => {
-  if (!watch) return
-
-  for (const copiedFile of copiedFiles) {
-    try {
-      rmSync(copiedFile, { recursive: true })
-    } catch (e) {
-      // do nothing
-    }
-  }
 }


### PR DESCRIPTION
# What?
A user tried to build a project without `views` folder. Not having a views folder is legit so we need to handle this case

<img width="920" alt="image" src="https://github.com/latitude-dev/latitude/assets/49499/95bce71b-75bf-4404-96e4-f6f076056d37">



