### PR TITLE
Remove empty params when data apps load.

### DIFF
--- a/.changeset/brown-mangos-marry.md
+++ b/.changeset/brown-mangos-marry.md
@@ -1,0 +1,5 @@
+---
+"@latitude-data/server": minor
+---
+
+Remove empty params from URL when data app loads

--- a/apps/server/src/lib/stores/setUrlParam.test.ts
+++ b/apps/server/src/lib/stores/setUrlParam.test.ts
@@ -1,0 +1,36 @@
+import { replaceState } from '$app/navigation'
+import { setUrlParam, ViewParams } from './viewParams'
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('$app/navigation', () => ({
+  replaceState: vi.fn(),
+}))
+
+describe('setUrlParam', () => {
+  it('should call replaceState with correct parameters', () => {
+    const newParams: ViewParams = {
+      foo: 'bar',
+      baz: undefined,
+      qux: null,
+      quux: '',
+    }
+    setUrlParam(newParams)
+
+    expect(replaceState).toHaveBeenCalledWith('?foo=$text:bar', {})
+  })
+
+  it('it shows clean url when no params', () => {
+    setUrlParam({ foo: '' })
+
+    expect(replaceState).toHaveBeenCalledWith('', {})
+  })
+
+  it('should not throw an error if replaceState is not available', () => {
+    // Simulate the scenario where replaceState throws an error
+    vi.mocked(replaceState).mockImplementationOnce(() => {
+      throw new Error('replaceState not available')
+    })
+
+    expect(() => setUrlParam({ foo: 'bar' })).not.toThrow()
+  })
+})

--- a/apps/server/src/lib/stores/viewParams.ts
+++ b/apps/server/src/lib/stores/viewParams.ts
@@ -11,7 +11,7 @@ export type ViewParams = {
 const getParamsFromUrl = () => {
   if (!browser) return {}
 
-  const urlParams = new URLSearchParams(globalThis.location.search)
+  const urlParams = new URLSearchParams(globalThis?.location?.search)
   const newParams: ViewParams = {}
   urlParams.forEach((value, key) => {
     newParams[key] = parse(value)
@@ -20,9 +20,12 @@ const getParamsFromUrl = () => {
 }
 
 export function setUrlParam(newParams: ViewParams) {
-  if (!browser) return
-
-  const newParamsString = LatitudeApi.buildParams(newParams)
+  const cleanParams = Object.fromEntries(
+    Object.entries(newParams).filter(
+      ([_, value]) => value !== undefined && value !== null && value !== '',
+    ),
+  )
+  const newParamsString = LatitudeApi.buildParams(cleanParams)
 
   // There are two ways to update the url: the default window.location.replaceState and svelte's replaceState
   // When using the default window.location.replaceState, sveltekit will print a warning in the console recommending to use svelte's replaceState instead
@@ -30,7 +33,8 @@ export function setUrlParam(newParams: ViewParams) {
   // To avoid the warning and the error, we use a try/catch block to catch the error and do nothing
 
   try {
-    replaceState(`?${newParamsString}`, {})
+    const urlParamsReplace = newParamsString ? `?${newParamsString}` : ''
+    replaceState(urlParamsReplace, {})
   } catch (_) {
     /* do nothing */
   } // replaceState fails when not ran within a svelte component


### PR DESCRIPTION
# What?
We want to avoid URLs in data apps with empty params like `?search=$text:`. Only when `search` has a non-empty value would appear in the URL

### Issue
https://github.com/latitude-dev/latitude/issues/255