### PR TITLE
Improved docs for SQL syntax

### DIFF
--- a/docs/queries/advanced/interpolation.mdx
+++ b/docs/queries/advanced/interpolation.mdx
@@ -5,56 +5,115 @@ description: 'Insert values into SQL queries without parametization'
 
 ## Introduction
 
-Interpolation refers to inserting values directly into the SQL code but without parametrization.
+Interpolation refers to inserting values directly into the SQL code without parametrization.
 
-By default, all of Latitude's logic is parametrized to independently send the query and values to the database and to detect possible SQL injection. Interpolating a value breaks the parametrization.
+In order to prevent SQL injection attacks, Latitude [parameterizes](https://cheatsheetseries.owasp.org/cheatsheets/Query_Parameterization_Cheat_Sheet.html)
+all queries to your db, by default. Parameter interpolation bypasses this protection and users should use it at their own risk. Read more about it
+in the [SQL Syntax](/queries/basics/sql-syntax-basics#adding-values-to-the-query) section.
 
 <Warning>Direct interpolation can lead to SQL injection vulnerabilities, allowing users to perform critical actions such as deleting a table.</Warning>
+
+## Why use interpolation?
+
+There are some cases where you might want to interpolate a value directly into the SQL query.
+- **unparameterizable values**: Depending on the database engine, some values cannot be parameterized. For example, table names cannot be parameterized in PostgreSQL.
+
+  For example:
+  ```sql
+    SELECT
+      user_name as {param('column_name')}
+    FROM users
+  ```
+  Running this query in PostgreSQL will throw an error because the column name cannot be parameterized. To fix it, we must interpolate the column name directly into the query:
+  ```sql
+    SELECT
+      user_name as {interpolate(param('column_name'))}
+    FROM users
+  ```
+
+- **Dynamic query keywords**: Most database engines only let you parameterize values, not keywords. For example, you cannot parameterize the `DESC` or `ASC` keyword in some engines.
+  ```sql
+    SELECT *
+    FROM users
+    ORDER BY users.id {param('order')}
+  ```
+  In order to fix this, you can interpolate the keyword directly into the query:
+  ```sql
+    SELECT *
+    FROM users
+    ORDER BY users.id {interpolate(param('order'))}
+  ```
 
 ## Syntax
 
 `interpolate()` allows you to send any parenthesized logic directly to the database. Let's look at some examples:
 
-```
+```sql
 interpolate({your_logic_here})
 ```
 
-- **Variable without interpolation**
+Take into account that interpolating any value will just add it straight to the query. This means that interpolating a string will not add quotes around it, so you must add them manually if needed.
 
-    ``` sql variable.sql
-    {companyFiltered = 'Latitude'}
+```sql
+SELECT *
+FROM table
+WHERE company = \'{interpolate('company_name')}\'
+```
 
-    SELECT *
-    FROM table
-    WHERE company = {companyFiltered}
-    ```
-    Will send the query parametized:
-    ``` sql
-    SELECT *
-    FROM table
-    WHERE company = $1
-    ```
-    And the value of `$1` independently:
-    ``` js
-    $1 = 'Latitude'
-    ```
-    This allows databases to check the values and see if there is a security vulnerability.
+Here we are also adding quotes around the interpolation to make sure the query is correctly formatted. We are also escaping the quotes, because otherwise everything inside a string is just considered a regular string and not compiled by Latitude.
 
-- **Variable with interpolation**
+## Example
 
-    ``` sql variable.sql
-    {companyFiltered = 'Latitude'}
+### Without interpolation
 
-    SELECT *
-    FROM table
-    WHERE company = {interpolate({companyFiltered})}
-    ```
-    Will send the query as it is:
-    ``` sql
-    SELECT *
-    FROM table
-    WHERE company = 'Latitude'
-    ```
+**Original query:**
+  ```sql
+  {companyName = 'Latitude'}
+
+  SELECT *
+  FROM table
+  WHERE company = {companyName}
+  ```
+
+**Compiled query:**
+  
+  The compiled query will have references to the values instead of the actual parameters.
+
+  ```sql
+  SELECT *
+  FROM table
+  WHERE company = $1
+  ```
+
+  The values for each reference will be sent to your database separately.
+
+  `$1 = 'Latitude'`
+
+  This process is done differently depending on the database engine you are using, but all of them are secure and prevent SQL injection attacks.
+
+
+### With interpolation
+
+**Original query:**
+  ```sql
+  {companyName = 'Latitude'}
+
+  SELECT *
+  FROM table
+  WHERE company = \'{interpolate(companyName)}\'
+  ```
+
+**Compiled query:**
+
+  Here the compiled query will contain the actual value of the parameter we used.
+
+  ```sql
+  SELECT *
+  FROM table
+  WHERE company = 'Latitude'
+  ```
+  
+  Be careful with this approach, as the value is directly inserted into the query, which can lead to SQL injection vulnerabilities.
 
 ### Other uses
 

--- a/docs/queries/basics/sql-syntax-basics.mdx
+++ b/docs/queries/basics/sql-syntax-basics.mdx
@@ -7,9 +7,7 @@ description: 'Learn the basics of queries, the syntax and how to reference sourc
 
 The SQL syntax you can use depends on the type of database your query is retrieving data from. 
 
-## Databases Reference
-
-You can check the documentation for each database or repository.
+You can check the syntax documentation for each database or repository to learn more about the specific SQL syntax you can use.
 
 <CardGroup cols={4}>
   <Card title="PostgreSQL" href="https://www.postgresql.org/docs/" icon={<svg width="32" height="32" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M35.0829 23.0968C34.9005 22.5447 34.423 22.16 33.8056 22.0677C33.5144 22.0243 33.181 22.0427 32.7864 22.1242C32.0986 22.2661 31.5883 22.3202 31.2158 22.3306C32.6214 19.9568 33.7645 17.2499 34.4224 14.7018C35.4864 10.5816 34.9179 8.70465 34.2534 7.85553C32.4952 5.60833 29.9298 4.40113 26.8349 4.36417C25.184 4.34401 23.7346 4.67009 22.9786 4.90449C22.2746 4.78017 21.5176 4.71089 20.7235 4.69809C19.2347 4.67425 17.9194 4.99889 16.7954 5.66609C16.1731 5.45553 15.1746 5.15889 14.0211 4.96961C11.3086 4.52417 9.1224 4.87121 7.52336 6.00113C5.58704 7.36913 4.68944 9.74609 4.85536 13.0659C4.90816 14.12 5.4976 17.3269 6.42576 20.3683C6.9592 22.1165 7.528 23.5682 8.11632 24.6834C8.95088 26.265 9.84368 27.1962 10.8461 27.5307C11.4078 27.7179 12.4286 27.849 13.5022 26.9546C13.6382 27.1195 13.82 27.2834 14.061 27.4355C14.3669 27.6285 14.741 27.7863 15.1149 27.8797C16.4616 28.2163 17.723 28.1322 18.7992 27.6602C18.8059 27.8517 18.811 28.0346 18.8154 28.1925C18.8224 28.4488 18.8296 28.7 18.8389 28.9349C18.9027 30.5234 19.0107 31.7586 19.3309 32.6227C19.3485 32.6703 19.3722 32.7427 19.397 32.8195C19.5568 33.3087 19.8238 34.1275 20.5034 34.7688C21.2069 35.4331 22.0579 35.6368 22.8374 35.6368C23.2283 35.6368 23.6014 35.5855 23.9285 35.5154C25.0947 35.2655 26.419 34.8847 27.3771 33.5202C28.283 32.2303 28.7234 30.2874 28.803 27.2261L28.832 26.9781L28.8509 26.8163L29.0643 26.8352L29.1194 26.8389C30.307 26.893 31.7594 26.6411 32.6514 26.2267C33.3562 25.8995 35.6146 24.7069 35.0829 23.0968Z" fill="black"/><path d="M33.0522 23.4095C29.5205 24.1381 29.2776 22.9423 29.2776 22.9423C33.0064 17.408 34.5653 10.3834 33.2202 8.66401C29.5503 3.97409 23.1978 6.19217 23.0917 6.24961L23.0576 6.25585C22.3599 6.11089 21.5791 6.02465 20.7015 6.01025C19.1035 5.98417 17.8914 6.42945 16.9715 7.12705C16.9715 7.12705 5.63923 2.45745 6.16627 12.9999C6.27843 15.2426 9.38019 29.9698 13.0797 25.5215C14.4319 23.8947 15.7386 22.5195 15.7386 22.5195C16.3874 22.9506 17.1642 23.1706 17.9786 23.0917L18.0419 23.0379C18.0223 23.2399 18.0312 23.4373 18.0672 23.6712C17.1141 24.7363 17.3943 24.9232 15.489 25.3155C13.561 25.713 14.6938 26.4205 15.433 26.6055C16.3295 26.8296 18.4034 27.1472 19.8047 25.1851L19.7488 25.4091C20.1221 25.7082 20.3843 27.3549 20.3405 28.8479C20.2965 30.3407 20.2672 31.3656 20.5613 32.1661C20.8557 32.9667 21.1488 34.7679 23.6536 34.2312C25.7463 33.7826 26.8309 32.62 26.9818 30.681C27.0888 29.3024 27.3311 29.5063 27.3463 28.2738L27.5407 27.6903C27.7648 25.8216 27.5763 25.2187 28.8656 25.4991L29.1791 25.5266C30.1279 25.5698 31.3701 25.3739 32.0991 25.0351C33.6687 24.3064 34.5997 23.0898 33.0519 23.4095H33.0522Z" fill="#336791"/><path d="M17.6345 14.003C17.3163 13.9586 17.028 13.9998 16.8822 14.1102C16.8003 14.1722 16.7749 14.2442 16.768 14.2938C16.7497 14.425 16.8416 14.5702 16.8981 14.645C17.0579 14.8569 17.2915 15.0025 17.5225 15.0346C17.556 15.0394 17.5894 15.0415 17.6225 15.0415C18.0078 15.0415 18.3582 14.7414 18.3891 14.5199C18.4278 14.2423 18.0251 14.0575 17.6345 14.0031V14.003ZM28.1776 14.0118C28.1472 13.7943 27.7603 13.7324 27.3931 13.7834C27.0264 13.8345 26.6709 14.0001 26.7006 14.218C26.7243 14.3876 27.0304 14.6769 27.3926 14.6769C27.4232 14.6769 27.4541 14.6748 27.4851 14.6705C27.727 14.6369 27.9043 14.4833 27.9886 14.3948C28.1169 14.2599 28.1913 14.1095 28.1776 14.0118Z" fill="white"/><path d="M34.227 23.3275C34.0924 22.9202 33.659 22.7891 32.9388 22.9379C30.8008 23.3792 30.035 23.0736 29.7836 22.8883C31.4456 20.356 32.8128 17.295 33.5504 14.439C33.8996 13.0861 34.0926 11.8298 34.1084 10.8056C34.1259 9.6816 33.9345 8.85568 33.5398 8.3512C31.9483 6.31712 29.6124 5.22608 26.7849 5.196C24.8412 5.17424 23.1988 5.67184 22.8804 5.81168C22.21 5.64496 21.4792 5.54256 20.6833 5.52944C19.2241 5.50592 17.9628 5.85536 16.9185 6.56752C16.4649 6.39872 15.2926 5.99632 13.8588 5.76512C11.3804 5.36608 9.41084 5.66848 8.00524 6.66432C6.32812 7.8528 5.55388 9.97728 5.7038 12.9786C5.75436 13.9882 6.32956 17.0946 7.23724 20.0693C8.43212 23.9845 9.731 26.201 11.0976 26.657C11.2576 26.7104 11.442 26.7477 11.6454 26.7477C12.144 26.7477 12.7552 26.5229 13.391 25.7582C14.1666 24.8276 14.969 23.9195 15.7971 23.0352C16.3342 23.3235 16.9244 23.4846 17.5281 23.5008C17.5292 23.5166 17.5308 23.5323 17.5323 23.548C17.4284 23.6719 17.3266 23.7977 17.227 23.9251C16.8088 24.4562 16.7217 24.5667 15.3755 24.844C14.9924 24.9232 13.9755 25.1328 13.9604 25.8459C13.9444 26.6251 15.1628 26.9523 15.3016 26.987C15.7854 27.1082 16.2515 27.1678 16.696 27.1678C17.7769 27.1678 18.7283 26.8125 19.4884 26.125C19.4651 28.9026 19.5809 31.6397 19.9144 32.4736C20.1875 33.1563 20.8547 34.8248 22.9619 34.8246C23.2712 34.8246 23.6115 34.7886 23.9859 34.7083C26.1852 34.2368 27.1404 33.2645 27.5099 31.121C27.7075 29.9754 28.0468 27.2398 28.2064 25.7725C28.5432 25.8776 28.9768 25.9258 29.4454 25.9256C30.423 25.9256 31.551 25.7179 32.2584 25.3894C33.0531 25.0203 34.4872 24.1146 34.227 23.3275ZM28.9894 13.412C28.9822 13.8453 28.9227 14.2386 28.8595 14.649C28.7913 15.0906 28.7211 15.5469 28.7033 16.101C28.6859 16.6403 28.7532 17.201 28.8184 17.743C28.9499 18.8382 29.0849 19.9656 28.5624 21.0781C28.4755 20.9242 28.3981 20.7652 28.3307 20.6019C28.2657 20.4445 28.1248 20.1915 27.9294 19.8413C27.1696 18.4782 25.39 15.2862 26.3009 13.9837C26.5723 13.596 27.2609 13.1974 28.9894 13.412ZM26.8942 6.07328C29.4276 6.12928 31.4316 7.07712 32.8505 8.89056C33.9387 10.2816 32.7404 16.6109 29.2713 22.071C29.2364 22.0267 29.2014 21.9826 29.1662 21.9384L29.1222 21.8835C30.0187 20.4027 29.8433 18.9376 29.6873 17.6387C29.6232 17.1056 29.5627 16.6021 29.578 16.1291C29.594 15.628 29.6603 15.1979 29.7244 14.7822C29.8032 14.2699 29.8833 13.7398 29.8612 13.115C29.8777 13.0494 29.8844 12.972 29.8756 12.88C29.8193 12.2808 29.1353 10.4875 27.7411 8.86432C26.9785 7.97632 25.8665 6.98272 24.348 6.31264C25.0011 6.17728 25.8942 6.05104 26.8942 6.07328ZM12.7182 25.1986C12.0174 26.0411 11.5337 25.8797 11.3745 25.8267C10.3377 25.4808 9.13484 23.2891 8.07436 19.8138C7.1566 16.8066 6.62044 13.7827 6.57788 12.9347C6.44396 10.2531 7.09388 8.384 8.50972 7.37968C10.8139 5.74528 14.6022 6.72368 16.1246 7.21968C16.1027 7.24128 16.08 7.26144 16.0584 7.28352C13.5603 9.80672 13.6195 14.1178 13.6257 14.3814C13.6254 14.483 13.634 14.627 13.6456 14.825C13.6888 15.5501 13.7688 16.8997 13.5548 18.428C13.3564 19.8482 13.794 21.2382 14.7556 22.2418C14.8543 22.3445 14.958 22.4424 15.0664 22.5349C14.2592 23.401 13.4763 24.2892 12.7182 25.1986ZM15.3875 21.6362C14.6124 20.8272 14.2604 19.7022 14.4217 18.5491C14.6473 16.9347 14.5641 15.5286 14.5193 14.7731C14.5129 14.6675 14.5073 14.5749 14.5041 14.5019C14.8691 14.1782 16.5603 13.2718 17.7662 13.5483C18.3166 13.6744 18.652 14.0491 18.7913 14.6939C19.5129 18.0318 18.8868 19.423 18.3838 20.5411C18.2801 20.7714 18.1822 20.9891 18.0985 21.2144L18.0337 21.3885C17.8696 21.8286 17.7169 22.2379 17.6222 22.6266C16.7984 22.6242 15.9969 22.2723 15.3875 21.6362ZM15.5139 26.1378C15.2734 26.0776 15.0569 25.9733 14.93 25.8866C15.0361 25.8368 15.2248 25.7688 15.5521 25.7013C17.1358 25.3754 17.3804 25.1451 17.9145 24.4667C18.0371 24.3112 18.1758 24.1349 18.3681 23.9202L18.3683 23.92C18.6547 23.5992 18.7856 23.6536 19.0232 23.7522C19.2156 23.8318 19.4032 24.0731 19.4792 24.3387C19.5152 24.4642 19.5555 24.7022 19.4233 24.8875C18.3075 26.4501 16.6816 26.4301 15.5139 26.1378ZM23.8025 33.8525C21.8651 34.2677 21.179 33.2789 20.727 32.1485C20.4352 31.4187 20.2918 28.128 20.3936 24.4938C20.3947 24.4467 20.3884 24.3998 20.3747 24.3547C20.3627 24.268 20.3446 24.1821 20.3204 24.0979C20.1692 23.5691 19.8004 23.1269 19.358 22.9435C19.1824 22.8707 18.8598 22.7371 18.4723 22.8362C18.5548 22.4955 18.6982 22.1109 18.8537 21.6942L18.9188 21.5192C18.9923 21.3216 19.0844 21.117 19.1817 20.9003C19.7081 19.7306 20.4291 18.1285 19.6467 14.509C19.3536 13.1533 18.3748 12.4912 16.8912 12.645C16.0017 12.7371 15.188 13.096 14.782 13.3019C14.7007 13.3431 14.6201 13.386 14.5404 13.4304C14.6537 12.0645 15.0817 9.51168 16.6827 7.89664C17.6907 6.87984 19.0332 6.37776 20.6689 6.4048C23.8918 6.4576 25.9585 8.11184 27.1249 9.4904C28.1299 10.6782 28.6742 11.875 28.8913 12.5205C27.258 12.3542 26.147 12.6768 25.584 13.4821C24.3588 15.2338 26.2542 18.6336 27.1651 20.2675C27.3321 20.567 27.4763 20.8258 27.5217 20.9358C27.8184 21.6549 28.2024 22.135 28.4827 22.4854C28.5688 22.5928 28.6521 22.697 28.7155 22.7878C28.2208 22.9306 27.3321 23.2602 27.4132 24.9077C27.3478 25.7344 26.8835 29.6048 26.6475 30.9723C26.336 32.7789 25.6713 33.4515 23.8025 33.8525ZM31.8899 24.5955C31.3841 24.8304 30.5376 25.0066 29.7332 25.0443C28.8451 25.0859 28.3929 24.9448 28.2865 24.8581C28.2366 23.8314 28.6187 23.7242 29.023 23.6106C29.0865 23.5926 29.1484 23.5752 29.2083 23.5544C29.2456 23.5846 29.2862 23.6147 29.3308 23.6442C30.0448 24.1155 31.3182 24.1662 33.116 23.795L33.1356 23.7912C32.8931 24.0179 32.4782 24.3222 31.8899 24.5955Z" fill="white"/></svg>} ></Card>
@@ -27,65 +25,110 @@ You can check the documentation for each database or repository.
 </CardGroup>
 
 
-## Data Source
+## Additional logic
 
-- **Source**: The `.sql` file will search for the nearest `.yaml` source file. This means that if there is no `.yaml` file at the same level, it will go to the previous one over and over again until it finds a source.
+With Latitude, you can use additional logic to make your queries more dynamic and powerful.
 
-- **Table**: In the FROM clause you only need to specify the table within the source. 
-  ```
-  FROM table_name
-  ```
+In any query, you can use **Logic Blocks**, which are always enclosed in curly brackets `{}`. These blocks can contain any logic you need, and they can be used
+to modify the query, add conditions, or even create loops.
 
-- **Columns**: If you want to refer to a specific column, you can use the table name followed by the column with a period in the middle. 
-  ```
-  JOIN second_table where second_table.column_name
-  ```
+Before sending the query to the database, Latitude compiles the logic in your query, and then sends the compiled query to the database. Your database will never
+see the logic, only the final query. This means that Latitude logic is compatible with any supported source type.
 
-## Reuse Queries
+Logic blocks can be used for:
+  - **Variables**: You can use logic to create variables and use them in your query.
+  - **Interpolation**: You can use logic to interpolate values into your query.
+  - **Conditions and Loops**: You can use logic to add conditions and create loops in your query.
+  - **Configuration**: You can use logic to configure your query.
 
-Each `.sql` file represents a single query, which can include subqueries or CTEs. 
+<Note>
+If you need to use curly brackets in the actual query, you must escape them with a backslash `\{` so that Latitude does not interpret them as logic blocks.
 
-Alternatively, you may split subqueries into separate files and reference them as required with `ref()`, see [Referencing other queries](../advanced/reference-queries) for more information.
+In the same note, curly brackets inside strings will not be treated as logic blocks. If you need to use curly brackets inside a string, you must escape the quotes with a backslash `\'`.
+</Note>
 
+### Variable definition and modification
+Variables can be defined and modified within the logic block. They can be used to store values and perform calculations.
 
-Check [Sources page](../../sources/how-to-configure-sources.mdx) to learn more.
+This can be done with the following syntax: `{variable_name = value or expression}`
 
-## SQL Logic
-
-You can extend the power of your SQL with the following advanced options:
-
-- [If / Else conditions](../logic/if-else.mdx)
-- [Interpolate Values](../logic/interpolate-values.mdx)
-- [Loops](../logic/loops.mdx)
-- [Variables](../logic/variables.mdx)
-
-Latitude logic must always be enclosed in curly brackets `{ }`.
-
-### Queries Parameterization Security
-
-By default, all logic in your project is parametrized, which means we send the SQL code and the logic values separately. This allows your database to double check that there is no attempt to make a SQL injection.
-
-Let's see an example, imagine  we are using this code that contains a variable.
 ```sql
-{foo = param('name')}
+-- variable definition
+{foo = 10}
+{bar = 5}
 
-SELECT
-  {foo} AS name
-  {foo + ' last_name'} AS name_and_surname
-```
-Instead of sending the code as it is, we send the following to the database
-
-``` sql parametized_query
-SELECT
-  $1 AS name
-  $2 AS name_and_surname
+-- variable modification
+{foo = foo + bar}
 ```
 
-And send it separately:
+Read more about variables in the [Variables](/queries/logic/variables) section.
 
-``` logic_values
-$1 = my_name 
-$2 = my_name_last_name
+### Adding values to the query
+
+Values can be added to the query just by enclosing them in curly brackets `{expression}`.
+
+```sql
+{user_name = 'Latitude'}
+SELECT * FROM users WHERE name = {user_name}
 ```
 
-This way the database can parse the content and prevent users from inserting SQL code into the input to, for example, delete the database.
+Values do not need to be defined as variables, you can use any expression or value directly in the query.
+
+```sql
+{user_name = 'Latitude'}
+SELECT *
+FROM users
+WHERE name = {user_name} -- variable
+AND age > {18} -- value
+AND created_at > {param('register_date')} -- function
+```
+
+By default, all values will always be [safely parameterized](https://cheatsheetseries.owasp.org/cheatsheets/Query_Parameterization_Cheat_Sheet.html).
+This means that Latitude will not directly include the value to the query, but instead it adds a reference to the value and sends the value separately
+to the database.
+
+In the example above, the compiled query actually looks like this:
+
+`SELECT * FROM users WHERE name = $1 AND age > $2 AND created_at > $3`
+
+And we send the values to your database separately:
+
+`$1: 'Latitude'`
+`$2: 18`
+`$3: '2021-01-01'`
+
+How the actual reference looks like depends on your source type, all of them are compatible with this feature. This is a security measure to prevent
+SQL injection and other vulnerabilities.
+
+If you need to insert a value directly into the query bypassing this parameterization, you can use the `interpolate` function. Read more about
+it in the [Interpolation](/queries/advanced/interpolation) section.
+
+<Note>
+You can see how any query is compiled by using the **run** command from the CLI with the `--debug` option. Learn more about it in the [CLI documentation](/guides/development/latitude-cli#debugging-queries).
+</Note>
+
+### Conditions and Loops
+
+You can use logic blocks to add conditions and loops to your query. This can be done using the `{#if}` and `{#each}` blocks. These blocks will decide
+whether to include or exclude a part of the query based on the condition.
+
+```sql
+SELECT * FROM users
+{#if condition}
+WHERE name = 'Latitude'
+{#end}
+```
+
+To learn more about them, check the [Conditions](/queries/logic/if-else) and [Loops](/queries/logic/loops) sections.
+
+### Configuration
+
+Finally, some logic blocks can only be used to configure how Latitude will handle the query, but not to modify the query itself. This can be done using
+the `{@config}` block.
+
+```sql
+{@config ttl = 3600}
+-- rest of the query
+```
+
+To learn more about how to configure your query, check the [Query Configuration](/queries/advanced/config) section.

--- a/docs/queries/logic/if-else.mdx
+++ b/docs/queries/logic/if-else.mdx
@@ -1,5 +1,5 @@
 ---
-title: '{#if ...}'
+title: 'Conditions'
 description: 'Adjust your SQL code dynamically according to conditions'
 ---
 

--- a/docs/queries/logic/loops.mdx
+++ b/docs/queries/logic/loops.mdx
@@ -1,5 +1,5 @@
 ---
-title: '{#each ...}'
+title: 'Loops'
 description: 'Learn how to use loops to repeat SQL code from a list of elements.'
 
 ---


### PR DESCRIPTION
I removed the docs we had on basic regular SQL syntax (I think that we can skip that part, since our userbase most likely already knows basic SQL syntax, and we already link to each source's documentation). 
Instead, in that same place I added documentation on our custom syntax: what it is, how it works, and what can do.