### PR TITLE
feature: cli creates dockerfiles

### DIFF
--- a/.changeset/modern-nails-punch.md
+++ b/.changeset/modern-nails-punch.md
@@ -1,0 +1,5 @@
+---
+"@latitude-data/cli": minor
+---
+
+CLI now handles all docker-related configuration for the user, so we no longer rely on the templates being up to date in this regard.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -37,6 +37,7 @@
     "@web/rollup-plugin-copy": "^0.5.1",
     "prettier": "^3.1.1",
     "rollup": "^4.10.0",
+    "rollup-plugin-string": "^3.0.0",
     "typescript": "^5.2.2",
     "vite-tsconfig-paths": "^4.3.1",
     "vitest": "^1.3.1"
@@ -54,8 +55,8 @@
     "echarts"
   ],
   "dependencies": {
-    "@latitude-data/connector-factory": "workspace:*",
     "@inquirer/prompts": "^4.2.1",
+    "@latitude-data/connector-factory": "workspace:*",
     "@rudderstack/rudder-sdk-node": "^2.0.7",
     "@sentry/node": "^7.108.0",
     "ajv": "^8.12.0",

--- a/packages/cli/rollup.config.mjs
+++ b/packages/cli/rollup.config.mjs
@@ -9,6 +9,7 @@ import { config as dotenvConfig } from 'dotenv'
 import { copy } from '@web/rollup-plugin-copy'
 import { dirname, resolve as resolvePath } from 'path'
 import { fileURLToPath } from 'url'
+import { string } from 'rollup-plugin-string'
 
 const DIRNAME = dirname(fileURLToPath(import.meta.url))
 function getPackageVersion() {
@@ -42,6 +43,9 @@ export default {
     copy({ patterns: 'latitude-banner.txt' }),
     typescript(),
     commonjs(),
+    string({
+      include: '**/*.template',
+    }),
     // The preferBuiltins option is required to resolve the built-in modules in
     // Node.js over any installed packages in node_modules directory
     resolve({
@@ -92,6 +96,6 @@ export default {
     'configstore',
     'latest-version',
     '@sentry/node',
-    '@latitude-data/connector-factory'
+    '@latitude-data/connector-factory',
   ],
 }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -35,15 +35,19 @@ if (process.env.NODE_ENV === 'development') {
 }
 
 CLI.command('start')
-  .describe('Setup you data project with an example data source')
+  .describe('Start a Latitude app from a template')
   .option('--name', 'Name of the project')
   .option('--template', 'Template to use for the Latitude app')
   .option('--port', 'Port to run the Latitude app on')
   .action(startCommand)
 
 CLI.command('update')
-  .describe('Update latitude app.You can define the version with --version')
-  .option('--fix', 'Installed the version in your latitude.json file')
+  .describe('Update latitude app. You can define the version with --version')
+  .option('--fix', 'Installs the version defined in latitude.json')
+  .option(
+    '--force',
+    'Updates latitude and overrides Dockerfile and .dockerignore files',
+  )
   .action(updateCommand)
 
 CLI.command('telemetry')

--- a/packages/cli/src/commands/update/index.ts
+++ b/packages/cli/src/commands/update/index.ts
@@ -1,6 +1,5 @@
 import config from '$src/config'
 import findOrCreateConfigFile from '$src/lib/latitudeConfig/findOrCreate'
-import getLatestVersion from '$src/lib/latitudeConfig/getLatestVersion'
 import getLatitudeVersions, {
   getInstalledVersion,
 } from '$src/lib/getAppVersions'
@@ -37,7 +36,7 @@ async function getVersions({ fix }: { fix: boolean }) {
   if (fix) {
     return {
       oldVersion: getInstalledVersion(config.appDir),
-      newVersion: await getLatestVersion(),
+      newVersion: latitudeJson.data.version,
     }
   }
 
@@ -64,8 +63,9 @@ async function getVersions({ fix }: { fix: boolean }) {
 
 // If --fix flag is passed, use the version defined in latitude.json This means
 // user had installed a different version and wants to fix it
-async function updateCommand(args: { fix?: boolean }) {
+async function updateCommand(args: { fix?: boolean; force?: boolean }) {
   const fix = args.fix ?? false
+  const force = args.force ?? false
   const { oldVersion, newVersion } = await getVersions({ fix })
 
   if (!newVersion) process.exit(1)
@@ -75,7 +75,7 @@ async function updateCommand(args: { fix?: boolean }) {
     properties: { fixingVersion: fix, oldVersion, newVersion },
   })
 
-  return updateApp({ version: newVersion })
+  return updateApp({ version: newVersion, force })
 }
 
 export default setRootDir(updateCommand)

--- a/packages/cli/src/lib/setupApp/index.test.ts
+++ b/packages/cli/src/lib/setupApp/index.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { existsSync, writeFileSync } from 'fs'
+import { addDockerfiles } from '.'
+
+vi.mock('fs', () => ({
+  existsSync: vi.fn(),
+  writeFileSync: vi.fn(),
+}))
+
+vi.mock('path', () => ({
+  default: {
+    resolve: (...args: string[]) => args.join('/'),
+  },
+}))
+
+vi.mock('$src/config', () => ({
+  default: {
+    rootDir: '/mocked/dir',
+  },
+}))
+
+describe('addDockerfiles', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('should create both .dockerignore and Dockerfile when they do not exist', async () => {
+    ;(existsSync as any).mockReturnValue(false)
+
+    addDockerfiles({ force: false })
+
+    expect(writeFileSync).toHaveBeenCalledTimes(2)
+    expect(writeFileSync).toHaveBeenCalledWith(
+      '/mocked/dir/.dockerignore',
+      expect.any(String),
+    )
+    expect(writeFileSync).toHaveBeenCalledWith(
+      '/mocked/dir/Dockerfile',
+      expect.any(String),
+    )
+  })
+
+  it('should not create files when they exist and force is false', async () => {
+    ;(existsSync as any).mockReturnValue(true)
+
+    addDockerfiles({ force: false })
+
+    expect(writeFileSync).not.toHaveBeenCalled()
+  })
+
+  it('should force create files even when they exist', async () => {
+    ;(existsSync as any).mockReturnValue(true)
+
+    addDockerfiles({ force: true })
+
+    expect(writeFileSync).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/cli/src/lib/sync/syncViews/index.test.ts
+++ b/packages/cli/src/lib/sync/syncViews/index.test.ts
@@ -34,7 +34,7 @@ describe('snycFnFactory', () => {
     })
 
     afterAll(() => {
-      fs.rmdirSync(rootDir, { recursive: true })
+      fs.rmSync(rootDir, { recursive: true })
     })
 
     it('handle add file', () => {

--- a/packages/cli/src/lib/updateApp/index.ts
+++ b/packages/cli/src/lib/updateApp/index.ts
@@ -2,9 +2,10 @@ import chalk from 'chalk'
 import config from '$src/config'
 import findConfigFile from '../latitudeConfig/findConfigFile'
 import fsExtra from 'fs-extra'
-import installAppDependencies from '../setupApp/installDependencies'
+import installDependencies from '../setupApp/installDependencies'
 import installLatitudeServer from '../installLatitudeServer'
 import { onError } from '$src/utils'
+import { addDockerfiles } from '../setupApp'
 
 async function updateConfigFile({ version }: { version: string }) {
   const latitudeJson = findConfigFile()
@@ -24,8 +25,15 @@ async function updateConfigFile({ version }: { version: string }) {
   }
 }
 
-export default async function updateApp({ version }: { version: string }) {
+export default async function updateApp({
+  force = false,
+  version,
+}: {
+  force: boolean
+  version: string
+}) {
   await updateConfigFile({ version })
   await installLatitudeServer({ version })
-  await installAppDependencies()
+  await installDependencies()
+  addDockerfiles({ force })
 }

--- a/packages/cli/src/templates/Dockerfile.template
+++ b/packages/cli/src/templates/Dockerfile.template
@@ -1,0 +1,31 @@
+FROM node:18-slim AS base
+
+RUN apt-get update && apt-get install -y curl
+RUN npm install -g @latitude-data/cli
+
+FROM base AS builder
+
+WORKDIR /usr/src/app
+
+COPY package.jso[n] .
+COPY latitude.json .
+
+RUN latitude telemetry --disable
+RUN latitude setup
+
+FROM builder AS runner
+
+WORKDIR /usr/src/app
+
+COPY --from=builder /usr/src/app/node_module[s] ./node_modules
+COPY --from=builder /usr/src/app/.latitude ./
+COPY --from=builder /usr/src/app/latitude.json ./latitude.json
+COPY . .
+
+RUN latitude build
+
+WORKDIR /usr/src/app/build
+
+EXPOSE 3000
+
+CMD ["node", "build"]

--- a/packages/cli/src/templates/dockerignore.template
+++ b/packages/cli/src/templates/dockerignore.template
@@ -1,0 +1,6 @@
+.git*
+.latitude
+README.md
+build
+fly.toml
+node_modules

--- a/packages/cli/src/types.d.ts
+++ b/packages/cli/src/types.d.ts
@@ -1,0 +1,4 @@
+declare module '*.template' {
+  const content: string
+  export default content
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -10,6 +10,7 @@
       "$src/*": ["src/*"]
     }
   },
+  "files": ["src/types.d.ts"],
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/cli/vitest.config.js
+++ b/packages/cli/vitest.config.js
@@ -1,7 +1,13 @@
 // vitest.config.ts
-import { defineConfig } from 'vitest/config'
 import tsconfigPaths from 'vite-tsconfig-paths'
+import { defineConfig } from 'vitest/config'
+import { string } from 'rollup-plugin-string'
 
 export default defineConfig({
-  plugins: [tsconfigPaths()],
+  plugins: [
+    tsconfigPaths(),
+    string({
+      include: '**/*.template',
+    }),
+  ],
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -380,6 +380,9 @@ importers:
       rollup:
         specifier: ^4.10.0
         version: 4.10.0
+      rollup-plugin-string:
+        specifier: ^3.0.0
+        version: 3.0.0
       typescript:
         specifier: ^5.2.2
         version: 5.3.3
@@ -20427,6 +20430,12 @@ packages:
       style-inject: 0.3.0
     transitivePeerDependencies:
       - ts-node
+    dev: true
+
+  /rollup-plugin-string@3.0.0:
+    resolution: {integrity: sha512-vqyzgn9QefAgeKi+Y4A7jETeIAU1zQmS6VotH6bzm/zmUQEnYkpIGRaOBPY41oiWYV4JyBoGAaBjYMYuv+6wVw==}
+    dependencies:
+      rollup-pluginutils: 2.8.2
     dev: true
 
   /rollup-pluginutils@2.8.2:


### PR DESCRIPTION
# WHAT

Right now there's an implicit dependency between our templates and CLI via the docker configuration that the templates include. From now on CLI is in charge of including package.json, dockerignore and dockerfile files, effectively eliminating this hidden dependency.