### PR TITLE
patch: add package version to dockerfile

### DIFF
--- a/.changeset/few-buses-drum.md
+++ b/.changeset/few-buses-drum.md
@@ -1,0 +1,5 @@
+---
+"@latitude-data/cli": patch
+---
+
+Add cli version to dockerfile

--- a/packages/cli/src/lib/addDockerfiles/_shared.ts
+++ b/packages/cli/src/lib/addDockerfiles/_shared.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk'
 import { writeFileSync } from 'fs'
-import dockerfileTemplate from '../../templates/Dockerfile.template'
+import dockerfileTemplate from '../../templates/Dockerfile'
 import dockerignoreTemplate from '../../templates/dockerignore.template'
 
 export function writeFile({
@@ -11,7 +11,7 @@ export function writeFile({
   path: string
 }) {
   const template =
-    type === 'dockerfile' ? dockerfileTemplate : dockerignoreTemplate
+    type === 'dockerfile' ? dockerfileTemplate() : dockerignoreTemplate
   try {
     writeFileSync(path, template)
   } catch (e) {

--- a/packages/cli/src/templates/Dockerfile.ts
+++ b/packages/cli/src/templates/Dockerfile.ts
@@ -1,7 +1,9 @@
+export default function DockerfileTemplate() {
+  return `
 FROM node:18-slim AS base
 
 RUN apt-get update && apt-get install -y curl
-RUN npm install -g @latitude-data/cli
+RUN npm install -g @latitude-data/cli@${process.env.PACKAGE_VERSION}
 
 FROM base AS builder
 
@@ -29,3 +31,5 @@ WORKDIR /usr/src/app/build
 EXPOSE 3000
 
 CMD ["node", "build"]
+`
+}


### PR DESCRIPTION
This commmit adds the cli package version to the dockerfile, this way we ensure that whenever the cli version changes and the user updates the project the dockerfile downloads the correct cli version for building the production build.