### PR TITLE
hotfix: nested query folders not found

### DIFF
--- a/.changeset/cold-lies-cheat.md
+++ b/.changeset/cold-lies-cheat.md
@@ -1,0 +1,6 @@
+---
+"@latitude-data/source-manager": patch
+"@latitude-data/server": patch
+---
+
+fixes regression that caused nested queries to not be found

--- a/apps/server/scripts/run_query/index.ts
+++ b/apps/server/scripts/run_query/index.ts
@@ -39,7 +39,7 @@ async function runQuery(
   debug = false,
 ) {
   try {
-    const source = await sourceManager.loadFromQuery(query)
+    const { source } = await sourceManager.loadFromQuery(query)
     const compiledQuery = await source.compileQuery({
       queryPath: query,
       params,

--- a/apps/server/src/routes/api/queries/[...query]/+server.ts
+++ b/apps/server/src/routes/api/queries/[...query]/+server.ts
@@ -6,7 +6,6 @@ type Props = { params: { query?: string }; url: URL }
 
 export async function GET({ params: args, url }: Props) {
   const { query } = args
-
   try {
     const { params, force, download } = await getQueryParams(url)
     const { queryResult, compiledQuery } = await findOrCompute({

--- a/apps/server/src/routes/api/queries/[...query]/server.test.ts
+++ b/apps/server/src/routes/api/queries/[...query]/server.test.ts
@@ -30,10 +30,13 @@ vi.mock('$lib/server/sourceManager', async () => {
         }
 
         return {
-          compileQuery: (request: QueryRequest) =>
-            connector.compileQuery(request),
-          runCompiledQuery: (compiledQuery: CompiledQuery) =>
-            connector.runCompiled(compiledQuery),
+          source: {
+            compileQuery: (request: QueryRequest) =>
+              connector.compileQuery(request),
+            runCompiledQuery: (compiledQuery: CompiledQuery) =>
+              connector.runCompiled(compiledQuery),
+          },
+          sourceFilePath: filePath,
         }
       },
     },

--- a/packages/source_manager/src/index.test.ts
+++ b/packages/source_manager/src/index.test.ts
@@ -47,10 +47,10 @@ describe('SourceManager', () => {
     const connector1 = await sourceManager.loadFromQuery(query1Path)
     const connector2 = await sourceManager.loadFromQuery(query2Path)
     expect(readFileSpy).toHaveBeenCalledOnce() // Only read config file once
-    expect(connector1).toBe(connector2)
+    expect(connector1.source).toBe(connector2.source)
 
-    await connector1.compileQuery({ queryPath: query1Path })
-    await connector1.compileQuery({ queryPath: query2Path })
+    await connector1.source.compileQuery({ queryPath: query1Path })
+    await connector1.source.compileQuery({ queryPath: query2Path })
     expect(mockCreateConnector).toHaveBeenCalledOnce() // Only instanced once
   })
 })
@@ -79,14 +79,14 @@ describe('loadFromQuery', () => {
 
   it('finds and loads the source from any query in the same directory', async () => {
     const sourceManager = new SourceManager('/path/to/queries')
-    const connector = await sourceManager.loadFromQuery('query')
+    const { source: connector } = await sourceManager.loadFromQuery('query')
     expect(connector).toBeDefined()
   })
 
   it('finds and loads the source from any query in a nested directory', async () => {
     const sourceManager = new SourceManager('/path/to/queries')
-    const connector = await sourceManager.loadFromQuery('query')
-    const nestedConnector =
+    const { source: connector } = await sourceManager.loadFromQuery('query')
+    const { source: nestedConnector } =
       await sourceManager.loadFromQuery('nestedQuery/query')
     expect(connector).toBeDefined()
     expect(nestedConnector).toBeDefined()
@@ -95,8 +95,8 @@ describe('loadFromQuery', () => {
 
   it('finds and loads the source from a query in a nested directory with a source file', async () => {
     const sourceManager = new SourceManager('/path/to/queries')
-    const connector = await sourceManager.loadFromQuery('query')
-    const nestedConnector =
+    const { source: connector } = await sourceManager.loadFromQuery('query')
+    const { source: nestedConnector } =
       await sourceManager.loadFromQuery('nestedSource/query')
     expect(connector).toBeDefined()
     expect(nestedConnector).toBeDefined()

--- a/packages/source_manager/src/index.ts
+++ b/packages/source_manager/src/index.ts
@@ -24,7 +24,9 @@ export default class SourceManager {
    * Finds the source configuration file in the given path and loads it
    * @param path - The path to any file in the source directory. This could be the source configuration file itself or any other query in the directory.
    */
-  async loadFromQuery(query: string): Promise<Source> {
+  async loadFromQuery(
+    query: string,
+  ): Promise<{ source: Source; sourceFilePath: string }> {
     const filePath = path.join(
       this.queriesDir,
       query.endsWith('.sql') ? query : `${query}.sql`,
@@ -40,17 +42,20 @@ export default class SourceManager {
       throw new QueryNotFoundError(`Query file not found at ${filePath}`)
     }
 
-    const sourceFile = await findSourceConfigFromQuery({
+    const sourceFilePath = await findSourceConfigFromQuery({
       query,
       queriesDir: this.queriesDir,
     })
 
-    if (!this.instances[sourceFile]) {
-      const config = readSourceConfig(sourceFile)
-      this.instances[sourceFile] = new Source(sourceFile, config)
+    if (!this.instances[sourceFilePath]) {
+      const config = readSourceConfig(sourceFilePath)
+      this.instances[sourceFilePath] = new Source(sourceFilePath, config)
     }
 
-    return this.instances[sourceFile]!
+    return {
+      source: this.instances[sourceFilePath]!,
+      sourceFilePath: sourceFilePath,
+    }
   }
 
   /**

--- a/packages/source_manager/src/lib/findSourceFile/index.test.ts
+++ b/packages/source_manager/src/lib/findSourceFile/index.test.ts
@@ -21,6 +21,12 @@ describe('findQueryFile', () => {
           'query.sql': 'Some query',
           nested: {
             'query.sql': 'Some nested query',
+            nnested: {
+              'source.yml': 'Nested source config file',
+              sql: {
+                'test.sql': 'Some very nested query',
+              },
+            },
           },
         },
         invalid: {
@@ -35,18 +41,34 @@ describe('findQueryFile', () => {
     vi.restoreAllMocks()
   })
 
-  it('finds the correct source config file from any query', async () => {
+  it('finds the correct source config file from root query', async () => {
     const result = await findSourceConfigFromQuery({
       queriesDir: ROOT_FOLDER,
       query: 'valid/query',
     })
+    const sourcePath = `${ROOT_FOLDER}/valid/source.yml`
+    expect(result).toEqual(sourcePath)
+  })
+
+  it('finds correct source config from nested query', async () => {
+    const sourcePath = `${ROOT_FOLDER}/valid/source.yml`
     const nestedResult = await findSourceConfigFromQuery({
       queriesDir: ROOT_FOLDER,
       query: 'valid/nested/query',
     })
-    const sourcePath = `${ROOT_FOLDER}/valid/source.yml`
-    expect(result).toEqual(sourcePath)
+
     expect(nestedResult).toEqual(sourcePath)
+  })
+
+  it('finds correct nexted source config from nested query', async () => {
+    const veryNestedResult = await findSourceConfigFromQuery({
+      queriesDir: ROOT_FOLDER,
+      query: 'valid/nested/nnested/sql/test',
+    })
+
+    expect(veryNestedResult).toEqual(
+      `${ROOT_FOLDER}/valid/nested/nnested/source.yml`,
+    )
   })
 
   it('should throw a QueryNotFoundError if the .sql file does not exist', async () => {

--- a/packages/source_manager/src/source.test.ts
+++ b/packages/source_manager/src/source.test.ts
@@ -52,7 +52,7 @@ describe('Source', () => {
   })
 
   it('initializes with the correct path and config', async () => {
-    const source = await sourceManager.loadFromQuery('query')
+    const { source } = await sourceManager.loadFromQuery('query')
 
     expect(source.path).toBe(`${QUERIES_DIR}/source.yml`)
     expect(source.type).toBe(sourceSchema.type)
@@ -60,7 +60,7 @@ describe('Source', () => {
   })
 
   it('does not instantiate the connector until it is needed', async () => {
-    const source = await sourceManager.loadFromQuery('query')
+    const { source } = await sourceManager.loadFromQuery('query')
     expect(mockCreateConnector).not.toHaveBeenCalled()
 
     await source.compileQuery({ queryPath: 'query', params: {} })
@@ -68,7 +68,7 @@ describe('Source', () => {
   })
 
   it('reuses the same connector for multiple queries', async () => {
-    const source = await sourceManager.loadFromQuery('query')
+    const { source } = await sourceManager.loadFromQuery('query')
     await source.compileQuery({ queryPath: 'query', params: {} })
     await source.compileQuery({ queryPath: 'nested/query', params: {} })
 
@@ -76,7 +76,7 @@ describe('Source', () => {
   })
 
   it('returns the source config when compiling a query', async () => {
-    const source = await sourceManager.loadFromQuery('query')
+    const { source } = await sourceManager.loadFromQuery('query')
     const compiledQuery = await source.compileQuery({
       queryPath: 'query',
       params: {},
@@ -87,7 +87,7 @@ describe('Source', () => {
 
   it('merges the source config with the defined config in the query, prioritizing the query config', async () => {
     fs.writeFileSync(`${QUERIES_DIR}/query.sql`, `{@config ttl = 12345}`)
-    const source = await sourceManager.loadFromQuery('query')
+    const { source } = await sourceManager.loadFromQuery('query')
     const compiledQuery = await source.compileQuery({
       queryPath: 'query',
       params: {},


### PR DESCRIPTION
In a prior commit we introduced a regression that caused nested queries to not be found by the CLI during development. This commit fixes this issue.

fixes #348 