### PR TITLE
Add the ability for adding secrets to Latitude clould deployed apps

### DIFF
--- a/.changeset/bright-rules-try.md
+++ b/.changeset/bright-rules-try.md
@@ -1,0 +1,5 @@
+---
+"@latitude-data/cli": minor
+---
+
+Add the ability of adding secure environment variables to Latitude Cloud

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - next
   pull_request:
     branches:
       - main
+      - next
 
 jobs:
   e2e:

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - next
   pull_request:
     branches:
       - main
+      - next
 
 jobs:
   linter:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - next
   pull_request:
     branches:
       - main
+      - next
 
 jobs:
   test:

--- a/apps/server/src/routes/+layout.svelte
+++ b/apps/server/src/routes/+layout.svelte
@@ -1,12 +1,12 @@
 <script>
   import { theme } from '@latitude-data/client'
   const defaultTheme = theme.skins.themes[1]
-  
+
   import { Alert, ThemeProvider } from '@latitude-data/svelte'
-  
+
   import '../assets/app.css'
-  import "@latitude-data/svelte/styles.css"
-  
+  import '@latitude-data/svelte/styles.css'
+
   import { onMount } from 'svelte'
   import { init as initQueries } from '$lib/stores/queries'
   import { setUrlParam, useViewParams } from '$lib/stores/viewParams'

--- a/docs/guides/deploy/latitude_cloud.mdx
+++ b/docs/guides/deploy/latitude_cloud.mdx
@@ -32,5 +32,9 @@ latitude deploy
 ```
 
 ## Secrets
+Is recomended to use secrets to store sensitive information like database credentials used in your sources. You can add secrets to your project by running the following command:
 
-*COMMING SOON*
+```bash
+latitude secrets add LATITUDE__DATABASE__PASSWORD=your_super_secret_password
+```
+<Note>Secrets are stored encrypted in our cloud infrastructure. They're only accessible by your app when is deployed</Note>

--- a/docs/sources/credentials.mdx
+++ b/docs/sources/credentials.mdx
@@ -22,3 +22,5 @@ details:
 At runtime, Latitude will check the environment for a LATITUDE\_\_PASSWORD env var and use it.
 
 Read more on how to declare env vars – for both local development and production builds – in the [env vars section](/guides/development/environment-variables).
+
+<Note>If you deploy with Latitude Cloud, you can store securely your secrets with [Latitude CLI secrets](/guides/deploy/latitude_cloud#secrets) command. Also available in our **FREE tier**</Note>

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -18,6 +18,8 @@ import startCommand from './commands/start'
 import telemetryCommand from './commands/telemetry'
 import updateCommand from './commands/update'
 import createTokenCommand from './commands/cloud/tokens/create'
+import addSecretCommand from './commands/cloud/secrets/add'
+import removeSecretCommand from './commands/cloud/secrets/remove'
 import { onError } from './utils'
 
 initSentry()
@@ -123,6 +125,14 @@ CLI.command('cancel')
 CLI.command('tokens create')
   .describe('Creates an authentication token for Latitude Cloud')
   .action(createTokenCommand)
+CLI.command('secrets add')
+  .describe('Add an environment variable to your Latitude Cloud')
+  .example('secrets add MY_SECRET=some_secret_value')
+  .action(addSecretCommand)
+CLI.command('secrets remove')
+  .describe('Remove an environment variable from your Latitude Cloud')
+  .example('secrets remove MY_SECRET')
+  .action(removeSecretCommand)
 
 async function init() {
   const argv = CLI.parse(process.argv, {

--- a/packages/cli/src/commands/cloud/secrets/add/index.ts
+++ b/packages/cli/src/commands/cloud/secrets/add/index.ts
@@ -1,0 +1,31 @@
+import chalk from 'chalk'
+import ora from 'ora'
+import findConfigFile from '$src/lib/latitudeConfig/findConfigFile'
+import tracked from '$src/lib/decorators/tracked'
+import { ApiError, request } from '$src/lib/server'
+import { CommonCLIArgs } from '$src/types'
+
+type Props = CommonCLIArgs & { _: string[] }
+async function addSecret({ _ }: Props) {
+  const latitudeJson = findConfigFile()
+  const app = latitudeJson.data.name!
+  const secret = _[0]
+  const spinner = ora('Adding secret...').start()
+  try {
+    await request({
+      method: 'POST',
+      path: '/api/secrets/add',
+      data: JSON.stringify({ app, secret }),
+    })
+  } catch (err) {
+    const error = err as ApiError
+    spinner.stop()
+    error.displayErrorDetails({ message: 'Failed to add secret' })
+    process.exit(1)
+  }
+
+  spinner.stop()
+  console.log(chalk.green('Secret added 🤫.'))
+}
+
+export default tracked('addSecretCommand', addSecret)

--- a/packages/cli/src/commands/cloud/secrets/remove/index.ts
+++ b/packages/cli/src/commands/cloud/secrets/remove/index.ts
@@ -1,0 +1,31 @@
+import chalk from 'chalk'
+import ora from 'ora'
+import findConfigFile from '$src/lib/latitudeConfig/findConfigFile'
+import tracked from '$src/lib/decorators/tracked'
+import { ApiError, request } from '$src/lib/server'
+import { CommonCLIArgs } from '$src/types'
+
+type Props = CommonCLIArgs & { _: string[] }
+async function removeSecret({ _ }: Props) {
+  const latitudeJson = findConfigFile()
+  const app = latitudeJson.data.name!
+  const secret = _[0]
+  const spinner = ora('Removing secret...').start()
+  try {
+    await request({
+      method: 'POST',
+      path: '/api/secrets/remove',
+      data: JSON.stringify({ app, secret }),
+    })
+  } catch (err) {
+    const error = err as ApiError
+    spinner.stop()
+    error.displayErrorDetails({ message: 'Failed to remove secret' })
+    process.exit(1)
+  }
+
+  spinner.stop()
+  console.log(chalk.green(`Secret ${secret} removed ✅`))
+}
+
+export default tracked('removeSecretCommand', removeSecret)

--- a/packages/cli/src/lib/telemetry/events.ts
+++ b/packages/cli/src/lib/telemetry/events.ts
@@ -15,6 +15,8 @@ export type TelemetryEventType =
   | 'telemetryDisabled'
   | 'credentialsCommand'
   | 'createTokenCommand'
+  | 'addSecretCommand'
+  | 'removeSecretCommand'
 
 type BaseEvent<T extends TelemetryEventType> = {
   event: T

--- a/packages/cli/src/templates/dockerignore.template
+++ b/packages/cli/src/templates/dockerignore.template
@@ -1,5 +1,6 @@
 .git*
 .latitude
+.env
 README.md
 build
 fly.toml


### PR DESCRIPTION
## Describe your changes
We want to allow users to store safely this database credentials. This PR introduces a command for setting a secret linked to the app

## Issue ticket number and link
https://github.com/latitude-dev/latitude/issues/347

## Checklist before requesting a review
- [x] Create `latitude secret set YOUR_SECRET=****`command
- [x] Create `latitude secret remove YOUR_SECRET`command
- [x] Docs
- [x] Changeset

## Next PR
- [ ] Do not create master key when doing app setup 
- [ ] Modify set master-key command. Instead of writing to `.env` file output the secret in `latitude credentials the terminal.

