### PR TITLE
minor: added signup/login message when attempting unauthorized deploy

### DIFF
--- a/.changeset/light-sloths-obey.md
+++ b/.changeset/light-sloths-obey.md
@@ -1,0 +1,5 @@
+---
+"@latitude-data/cli": minor
+---
+
+Added signup/login message when attempting deploy unauthorized

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,7 @@
 ## Issue ticket number and link
 
 ## Checklist before requesting a review
-- [ ] I have added thourough tests
+- [ ] I have added thorough tests
 - [ ] I have updated the documentation if necessary
 - [ ] I have added a human-readable description of the changes for the release notes
 - [ ] I have included a recorded video capture of the feature manually tested

--- a/packages/cli/src/commands/cloud/deploy/index.test.ts
+++ b/packages/cli/src/commands/cloud/deploy/index.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import deployCommand from '.'
+import chalk from 'chalk'
+
+vi.mock('$src/config', () => ({
+  default: {
+    dev: true,
+  },
+}))
+
+vi.mock('$src/lib/server', () => {
+  return {
+    request: vi.fn().mockRejectedValueOnce({
+      status: 401,
+      message: 'Unauthorized',
+    }),
+  }
+})
+
+vi.mock('$src/lib/latitudeConfig/findConfigFile', () => {
+  return {
+    default: vi.fn().mockReturnValue({
+      data: { name: 'test-app' },
+    }),
+  }
+})
+
+vi.mock('ora', () => {
+  return {
+    default: vi.fn().mockReturnValue({
+      start: function () {
+        return this
+      },
+      stop: function () {},
+    }),
+  }
+})
+
+describe('deployCommand', () => {
+  let consoleErrorMock: any
+
+  beforeEach(() => {
+    consoleErrorMock = vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    consoleErrorMock.mockRestore()
+  })
+
+  it('displays a correct message when deploying without being logged in', async () => {
+    await expect(deployCommand()).rejects.toThrow()
+    expect(consoleErrorMock).toHaveBeenCalledWith(
+      chalk.yellow(`
+You are not logged in. Please run the following command to sign up:
+  
+    ${chalk.cyan('latitude signup')}
+
+If you have already signed up, please run the following command to log in:
+
+    ${chalk.cyan('latitude login')}
+`),
+    )
+  })
+})

--- a/packages/cli/src/commands/cloud/deploy/index.ts
+++ b/packages/cli/src/commands/cloud/deploy/index.ts
@@ -5,7 +5,7 @@ import findConfigFile from '$src/lib/latitudeConfig/findConfigFile'
 import ora from 'ora'
 import pushDockerImage from './docker/push'
 import tracked from '$src/lib/decorators/tracked'
-import { request, sseRequest } from '$src/lib/server'
+import { ApiError, request, sseRequest } from '$src/lib/server'
 import { GITHUB_STARTS_BANNER } from '$src/commands/constants'
 
 function deployedMessage(url: string) {
@@ -94,7 +94,21 @@ async function deployCommand(
   })
     .then(({ body }) => JSON.parse(body))
     .catch((err) => {
-      console.error(chalk.red('Failed to get/create registry:', err.message))
+      if ((err as ApiError).status === 401) {
+        console.error(
+          chalk.yellow(`
+You are not logged in. Please run the following command to sign up:
+  
+    ${chalk.cyan('latitude signup')}
+
+If you have already signed up, please run the following command to log in:
+
+    ${chalk.cyan('latitude login')}
+`),
+        )
+      } else {
+        console.error(chalk.red('Failed to get/create registry:', err.message))
+      }
 
       process.exit(1)
     })

--- a/packages/cli/src/lib/server/index.ts
+++ b/packages/cli/src/lib/server/index.ts
@@ -10,7 +10,7 @@ type Options = {
   headers?: Record<string, string>
 }
 
-class ApiError extends Error {
+export class ApiError extends Error {
   status: number
   body: string
 

--- a/packages/cli/src/lib/telemetry/index.test.ts
+++ b/packages/cli/src/lib/telemetry/index.test.ts
@@ -15,8 +15,10 @@ const SELECT_ARGS = {
 }
 
 process.env['PACKAGE_VERSION'] = '1.0.0'
+
 vi.spyOn(os, 'platform').mockImplementation(() => 'darwin')
 vi.spyOn(os, 'release').mockImplementation(() => '20.6.0')
+
 const mockedCrypto = vi
   .spyOn(crypto, 'randomBytes')
   .mockImplementation(() => ({ toString: () => 'mocked-random-user-id' }))
@@ -55,6 +57,12 @@ vi.mock('@inquirer/prompts', async () => {
     select: mockedSelect,
   }
 })
+
+vi.mock('$src/config', () => ({
+  default: {
+    dev: false,
+  },
+}))
 
 const consoleMock = vi.spyOn(console, 'log').mockImplementation(() => undefined)
 

--- a/packages/cli/src/lib/telemetry/index.ts
+++ b/packages/cli/src/lib/telemetry/index.ts
@@ -6,6 +6,7 @@ import { select } from '@inquirer/prompts'
 import type { TelemetryEvent, TelemetryEventType } from './events'
 import chalk from 'chalk'
 import configStore from '$src/lib/configStore'
+import config from '$src/config'
 
 type TelemetryConfig = {
   enabled: boolean | undefined
@@ -61,6 +62,10 @@ export class Telemetry {
   }
 
   private async setup() {
+    if (config.dev) {
+      this.disable()
+      return this.enabled
+    }
     if (this.initialized) return this.enabled
     if (this.enabled !== undefined) return this.enabled
 


### PR DESCRIPTION
## Describe your changes
When you attempt to deploy a latitude deploy without signing up or logging in, we display a nice message.


https://github.com/latitude-dev/latitude/assets/1948929/14b55ab0-9e93-42ca-9943-79fc5525b0dc

## Checklist before requesting a review
- [x] I have added thorough tests
- [x] I have updated the documentation if necessary
- [x] I have added a human-readable description of the changes for the release notes
- [x] I have included a recorded video capture of the feature manually tested

