### PR TITLE
fix: cli production build on prerelease mode

### DIFF
--- a/.changeset/clever-seas-cry.md
+++ b/.changeset/clever-seas-cry.md
@@ -1,0 +1,5 @@
+---
+"@latitude-data/cli": patch
+---
+
+Empty change to trigger a release that fixes the cli build with proper build-time env variables

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -36,5 +36,11 @@ jobs:
         with:
           publish: pnpm release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CLI_SENTRY_DSN: ${{ secrets.CLI_SENTRY_DSN }}
+          CLI_SENTRY_ENABLED: 'true'
+          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+          LATITUDE_SERVER_HOST: ${{ secrets.LATITUDE_SERVER_HOST }}
+          LATITUDE_SERVER_PORT: ${{ secrets.LATITUDE_SERVER_PORT }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          TELEMETRY_CLIENT_KEY: ${{ secrets.TELEMETRY_CLIENT_KEY }}
+          TELEMETRY_URL: ${{ secrets.TELEMETRY_URL }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,11 +40,11 @@ jobs:
           # This expects us to have a script called release which does a build for our packages and calls changeset publish
           publish: pnpm release
         env:
-          LATITUDE_SERVER_HOST: ${{ secrets.LATITUDE_SERVER_HOST }}
-          LATITUDE_SERVER_PORT: ${{ secrets.LATITUDE_SERVER_PORT }}
-          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          TELEMETRY_URL: ${{ secrets.TELEMETRY_URL }}
-          TELEMETRY_CLIENT_KEY: ${{ secrets.TELEMETRY_CLIENT_KEY }}
           CLI_SENTRY_DSN: ${{ secrets.CLI_SENTRY_DSN }}
           CLI_SENTRY_ENABLED: 'true'
+          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+          LATITUDE_SERVER_HOST: ${{ secrets.LATITUDE_SERVER_HOST }}
+          LATITUDE_SERVER_PORT: ${{ secrets.LATITUDE_SERVER_PORT }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          TELEMETRY_CLIENT_KEY: ${{ secrets.TELEMETRY_CLIENT_KEY }}
+          TELEMETRY_URL: ${{ secrets.TELEMETRY_URL }}


### PR DESCRIPTION
## Describe your changes

We were building CLI without proper env variables at build time for prereleases.

## Checklist before requesting a review
noop