### PR TITLE
hotfix: http caching

### DIFF
--- a/.changeset/spicy-crabs-scream.md
+++ b/.changeset/spicy-crabs-scream.md
@@ -1,0 +1,7 @@
+---
+"@latitude-data/server": patch
+---
+
+hotfix: client-side cache was not being invalidated after data changed. This
+commit removes this cache for the time being, this results in a performance hit
+but it's mostly unnoticeable given backend cache is still in place.

--- a/apps/server/src/routes/api/queries/[...query]/+server.ts
+++ b/apps/server/src/routes/api/queries/[...query]/+server.ts
@@ -8,21 +8,15 @@ export async function GET({ params: args, url }: Props) {
   const { query } = args
   try {
     const { params, force, download } = await getQueryParams(url)
-    const { queryResult, compiledQuery } = await findOrCompute({
+    const { queryResult } = await findOrCompute({
       query: query ?? '',
       queryParams: params,
       force,
     })
-    const ttl = compiledQuery.config.ttl
-    let headers = {}
-    if (ttl) {
-      headers = { 'Cache-Control': `private, max-age=${ttl}` }
-    }
 
     if (download) {
       return new Response(queryResult.toCSV(), {
         headers: {
-          ...headers,
           'Content-Type': 'text/csv',
           'Content-Disposition': `attachment; filename="${
             query ?? 'query'
@@ -33,7 +27,6 @@ export async function GET({ params: args, url }: Props) {
     } else {
       return new Response(queryResult.toJSON(), {
         headers: {
-          ...headers,
           'Content-Type': 'application/json',
         },
         status: 200,

--- a/apps/server/src/routes/api/queries/[...query]/server.test.ts
+++ b/apps/server/src/routes/api/queries/[...query]/server.test.ts
@@ -1,15 +1,16 @@
-import cache from '$lib/query_service/query_cache'
-import { describe, it, expect, vi, beforeEach } from 'vitest'
 import QueryResult, { DataType } from '@latitude-data/query_result'
-import { MISSING_KEY } from '$lib/loadToken'
-import mockFs from 'mock-fs'
-import fs from 'fs'
-import { QUERIES_DIR } from '$lib/server/sourceManager'
-import { GET } from './+server'
 import TestConnector from '@latitude-data/test-connector'
-import type { CompiledQuery, QueryRequest } from '@latitude-data/base-connector'
+import cache from '$lib/query_service/query_cache'
+import fs from 'fs'
+import mockFs from 'mock-fs'
 import path from 'path'
+import { GET } from './+server'
+import { MISSING_KEY } from '$lib/loadToken'
+import { QUERIES_DIR } from '$lib/server/sourceManager'
 import { QueryNotFoundError } from '@latitude-data/source-manager'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import type { CompiledQuery, QueryRequest } from '@latitude-data/base-connector'
 
 const runQuerySpy = vi.fn()
 const connector = new TestConnector(QUERIES_DIR, {


### PR DESCRIPTION
## Describe your changes

We were adding a cache-control header that configured client-side caching but then we provided no way to invalidate this cache from the client. This hotfix removes the cache control header in order to ensure data is fresh. 

**Backend cache is still present**, so this change should result in minimal latency increase for users, in exchange for always-up-to-date data.

## Issue ticket number and link

#381 

## Checklist before requesting a review
- [x] I have added thorough tests (noop)
- [x] I have updated the documentation if necessary
- [x] I have added a human-readable description of the changes for the release notes
- [x] I have included a recorded video capture of the feature manually tested (noop)

