### PR TITLE
fix: runquery with parameters

### DIFF
--- a/.changeset/chilled-donkeys-hunt.md
+++ b/.changeset/chilled-donkeys-hunt.md
@@ -1,0 +1,5 @@
+---
+"@latitude-data/base-connector": patch
+---
+
+fix: runQuery did not work if the parent had parameters

--- a/.changeset/lazy-coins-enjoy.md
+++ b/.changeset/lazy-coins-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@latitude-data/server": patch
+---
+
+Adds error logs when a request fails to process

--- a/apps/server/src/lib/errors/handler.ts
+++ b/apps/server/src/lib/errors/handler.ts
@@ -9,5 +9,8 @@ export default function handleError(e: Error) {
     return new Response(e.message, { status: 404 })
   }
 
+  // TODO: Add sentry reporting
+  console.error(e)
+
   return new Response(clientError.message, { status: 500 })
 }

--- a/packages/connectors/base/src/index.ts
+++ b/packages/connectors/base/src/index.ts
@@ -307,6 +307,7 @@ export abstract class BaseConnector {
           ...context,
           request: { queryPath: queryName, params: {} },
           queryConfig: {}, // Subquery config does not affect the root query
+          resolvedParams: [], // Subquery should not have access to parent queries' resolved parameters
         })
 
         const subQueryResults = await this.runQuery(compiledSubQuery).then(

--- a/packages/connectors/base/src/supported_methods.test.ts
+++ b/packages/connectors/base/src/supported_methods.test.ts
@@ -305,6 +305,19 @@ describe('ref function', async () => {
 describe('runQuery function', async () => {
   afterEach(clearQueries)
 
+  it('does not contain resolvedParams from the parent query', async () => {
+    const connector = new MockConnector()
+    const mainQuery =
+      '{param("foo", "bar")} {result = runQuery("referenced_query")}'
+    const refQuery = 'ref'
+    const mainQueryPath = addFakeQuery(mainQuery)
+    addFakeQuery(refQuery, 'referenced_query')
+
+    await connector.run({ queryPath: mainQueryPath })
+
+    expect(ranQueries.length).toBe(2)
+  })
+
   it('runs a subquery and returns it as a value', async () => {
     const connector = new MockConnector()
     const mainQuery = "{result = runQuery('referenced_query')} {result.length}"


### PR DESCRIPTION
## Describe your changes
When we try to run a subquery with runQuery and its parent query has parameters, the db throws an error as we were passing parameters for the subquery that the db didn't know what to do with.

This commit fixes this issue.

https://github.com/latitude-dev/latitude/assets/1948929/5b2a2b3a-2ffb-4f4f-b880-63b56f5afdb7

## Checklist before requesting a review
- [x] I have added thorough tests
- [x] I have updated the documentation if necessary _noop_
- [x] I have added a human-readable description of the changes for the release notes
- [x] I have included a recorded video capture of the feature manually tested _noop_

