### PR TITLE
Fix: Old data was leaking into chart after update

### DIFF
--- a/.changeset/neat-ravens-reflect.md
+++ b/.changeset/neat-ravens-reflect.md
@@ -1,0 +1,5 @@
+---
+"@latitude-data/svelte": patch
+---
+
+Fix: When displaying data in a chart, updating the query result updated the chart, but it still displayed some values from the old result.

--- a/packages/client/svelte/src/lib/internal/ui/chart/_Echarts.svelte
+++ b/packages/client/svelte/src/lib/internal/ui/chart/_Echarts.svelte
@@ -103,7 +103,7 @@
     onWindowResize()
     return {
       update({ options: newOptions }: ChartableProps) {
-        echartsInstance.setOption({ ...options, ...newOptions })
+        echartsInstance.setOption({ ...options, ...newOptions }, { notMerge: true })
       },
       destroy() {
         if (resizeObserver) {


### PR DESCRIPTION
## Describe your changes
Updating the data loaded into a chart was still using some rows from the old query result, which made no sense.

Before fix:

https://github.com/latitude-dev/latitude/assets/57395395/9b672715-5209-4a5f-9482-a4bd0fd5bc5c

After fix:

https://github.com/latitude-dev/latitude/assets/57395395/b66ce44e-c60a-4960-bc89-c1a1fb827530

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have added thorough tests
- [ ] I have updated the documentation if necessary
- [x] I have added a human-readable description of the changes for the release notes
- [x] I have included a recorded video capture of the feature manually tested

