### PR TITLE
Fix: Properly handle object properties on Query Compiler

### DIFF
--- a/.changeset/nasty-spies-argue.md
+++ b/.changeset/nasty-spies-argue.md
@@ -1,0 +1,8 @@
+---
+"@latitude-data/sql-compiler": minor
+---
+
+Improved handling of object properties in query logic blocks. Now you can:
+ - Invoke methods from objects.
+ - Modify object properties.
+ - Access properties using optional chaining (the `?.` operator).

--- a/packages/connectors/compiler/src/compiler/operators.ts
+++ b/packages/connectors/compiler/src/compiler/operators.ts
@@ -45,22 +45,28 @@ export const UNARY_OPERATOR_METHODS: {
 }
 
 // https://github.com/estree/estree/blob/master/es5.md#memberexpression
-export const MEMBER_EXPRESSION_METHOD = (object: any, property: any): unknown =>
-  object[property]
+export const MEMBER_EXPRESSION_METHOD = (
+  object: any,
+  property: any,
+): unknown => {
+  const value = object[property]
+  return typeof value === 'function' ? value.bind(object) : value
+}
 
 // https://github.com/estree/estree/blob/master/es5.md#assignmentexpression
 export const ASSIGNMENT_OPERATOR_METHODS: {
   [operator: string]: (left: any, right: any) => unknown
 } = {
-  '+=': (left, right) => (left += right),
-  '-=': (left, right) => (left -= right),
-  '*=': (left, right) => (left *= right),
-  '/=': (left, right) => (left /= right),
-  '%=': (left, right) => (left %= right),
-  '<<=': (left, right) => (left <<= right),
-  '>>=': (left, right) => (left >>= right),
-  '>>>=': (left, right) => (left >>>= right),
-  '|=': (left, right) => (left |= right),
-  '^=': (left, right) => (left ^= right),
-  '&=': (left, right) => (left &= right),
+  '=': (_, right) => right,
+  '+=': (left, right) => left + right,
+  '-=': (left, right) => left - right,
+  '*=': (left, right) => left * right,
+  '/=': (left, right) => left / right,
+  '%=': (left, right) => left % right,
+  '<<=': (left, right) => left << right,
+  '>>=': (left, right) => left >> right,
+  '>>>=': (left, right) => left >>> right,
+  '|=': (left, right) => left | right,
+  '^=': (left, right) => left ^ right,
+  '&=': (left, right) => left & right,
 }

--- a/packages/connectors/compiler/src/error/errors.ts
+++ b/packages/connectors/compiler/src/error/errors.ts
@@ -102,13 +102,34 @@ export default {
     code: 'constant-reassignment',
     message: 'Cannot reassign a constant',
   },
+  invalidAssignment: {
+    code: 'invalid-assignment',
+    message: 'Invalid assignment',
+  },
+  invalidUpdate: (operation: string, type: string) => ({
+    code: 'invalid-update',
+    message: `Cannot use ${operation} operation on ${type}`,
+  }),
+
+  propertyNotExists: (property: string) => ({
+    code: 'property-not-exists',
+    message: `Property '${property}' does not exist on object`,
+  }),
   unknownFunction: (name: string) => ({
     code: 'unknown-function',
     message: `Unknown function: ${name}`,
   }),
-  functionCallError: (name: string, message: string) => ({
+  notAFunction: (objectType: string) => ({
+    code: 'not-a-function',
+    message: `Object '${objectType}' is callable`,
+  }),
+  namedFunctionCallError: (name: string, message: string) => ({
     code: 'function-call-error',
     message: `Error calling function '${name}': ${message}`,
+  }),
+  unnamedFunctionCallError: (message: string) => ({
+    code: 'function-call-error',
+    message: `Error calling function: ${message}`,
   }),
   invalidFunctionResultInterpolation: {
     code: 'invalid-function-result-interpolation',


### PR DESCRIPTION
## Describe your changes
Compiler did not properly handle object properties. Before this commit, you could not:
- Invoke object properties as methods
- Modify object properties values
- Allow optional chaining operator (`?.`)

### Invoke object properties as methods
Some variable types can contain functions that may be useful in the query compilation run-time. A clear example is Dates, where a Date can be passed to a query as a param, and we may want to run date-related methods.

```
{minDate = param('start_date')}  -- Returns a Date object

SELECT *
FROM table
WHERE year >= {minDate.getYear()}   -- You can now run the .getYear() method from the date object!
```

### Modify object properties as methods
You can now also modify the value from object properties such as arrays and hashes.

```
{ results = runQuery('other_query') }
{ results[0].name = 'foo' }  -- Modifying a property from an object

SELECT *
FROM table
WHERE name IN {#each results as row} {row.name} {/each}
```

### Allow optional chaining operator (`?.`)
The optional chaining operator allows you to read the value of a property located deep within a chain of connected objects without having to expressly validate that each reference in the chain is valid.

```
{ results = runQuery('other_query') }

SELECT *
FROM table
WHERE name = {results[0]?.name ?? 'default'}  -- If there are no results, it will return 'default'
```


## Checklist before requesting a review
- [x] I have added thorough tests
- [ ] I have updated the documentation if necessary
- [x] I have added a human-readable description of the changes for the release notes
- [ ] I have included a recorded video capture of the feature manually tested

