### PR TITLE
minor: change react peer dependency on react package

### DIFF
--- a/.changeset/light-rats-exercise.md
+++ b/.changeset/light-rats-exercise.md
@@ -1,0 +1,5 @@
+---
+"@latitude-data/react": patch
+---
+
+Changed react peer dependency to 16.8 and upwards

--- a/examples/sample-react/README.md
+++ b/examples/sample-react/README.md
@@ -20,11 +20,11 @@ At this point if you have a running Netflix latitude project in `localhost:3000`
 you should see everything ok.
 
 ### Copy `examples/sample-react`
-This is another way of running this React example. After copy the folder you need to change in the `examples/sample-react/package.json`
+This is another way of running this React example. After you've copied the folder you need to change in the `examples/sample-react/package.json`
 
 ```diff
 - "@latitude-data/react": "workspace:*",
-+ "@latitude-data/react": "0.2.0", // Or the version you want
++ "@latitude-data/react": "*", // Or the version you want
 ```
 
 After this change:

--- a/packages/client/react/package.json
+++ b/packages/client/react/package.json
@@ -44,8 +44,8 @@
     "tailwindcss-animate": "^1.0.7"
   },
   "peerDependencies": {
-    "react": "^17.0.0",
-    "react-dom": "^17.0.0"
+    "react": ">=16.8.0",
+    "react-dom": ">=16.8.0"
   },
   "devDependencies": {
     "@latitude-data/eslint-config": "workspace:*",


### PR DESCRIPTION
## Describe your changes
We were requiring *only* react 17 when in fact we can support any version from 16 upwards.
