### PR TITLE
feature: allow cli to work on non-tty envs

### DIFF
--- a/.changeset/light-roses-begin.md
+++ b/.changeset/light-roses-begin.md
@@ -1,0 +1,5 @@
+---
+"@latitude-data/cli": patch
+---
+
+Allows cli to run on non-tty environments

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -29,6 +29,7 @@ const CLI = sade('latitude')
 CLI.version(process.env.PACKAGE_VERSION ?? 'development')
   .option('--verbose', 'Enables verbose console logs')
   .option('--simulate-pro', 'Enable pro mode in development')
+  .option('--tty', 'Enables or disables TTY mode.')
 
 if (process.env.NODE_ENV === 'development') {
   CLI.option(

--- a/packages/cli/src/commands/dev/index.ts
+++ b/packages/cli/src/commands/dev/index.ts
@@ -11,14 +11,14 @@ import versionCheck from '$src/lib/decorators/versionCheck'
 
 export type Props = CommonCLIArgs & { open?: boolean; port?: number }
 
-async function devCommand(args: Props = {}) {
+async function devCommand(
+  { open = config.prod, port }: Props = { open: config.prod },
+) {
   await sync({
     watch: true,
   })
 
-  runDevServer(
-    await buildServerProps({ open: args?.open ?? config.pro, port: args.port }),
-  )
+  runDevServer(await buildServerProps({ open, port }))
 }
 
 const buildServerProps = async ({

--- a/packages/cli/src/commands/telemetry/index.ts
+++ b/packages/cli/src/commands/telemetry/index.ts
@@ -13,13 +13,13 @@ export default function telemetryCommand(args: Args = {}): void {
   const showStatus = args?.status !== undefined
 
   if (enable) {
-    telemetry.enable()
+    telemetry.enabled = true
     console.log(colors.blue('Telemetry enabled'))
   } else if (disable) {
-    telemetry.disable()
+    telemetry.enabled = false
     console.log(colors.blue('Telemetry disabled'))
   } else if (showStatus) {
-    telemetry.showStatus()
+    telemetry.enabled
   } else {
     console.log(
       colors.red(

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -3,30 +3,46 @@ import path from 'path'
 import { APP_FOLDER, LATITUDE_CONFIG_FILE } from './commands/constants'
 
 class CLIConfig {
+  public dev: boolean
+  public prod: boolean
+  public test: boolean
+
   public rootDir: string
-  public dev: boolean = true
-  public verbose: boolean = false
+  public verbose: boolean
+  public tty: boolean
 
   constructor({
-    dev,
     rootDir,
+    dev = true,
+    test = false,
+    prod = false,
     verbose = false,
+    tty = true,
   }: {
     rootDir: string
-    dev: boolean
+    dev?: boolean
+    test?: boolean
+    prod?: boolean
     verbose?: boolean
+    tty?: boolean
   }) {
     this.dev = dev
+    this.test = test
+    this.prod = prod
     this.rootDir = rootDir
     this.verbose = verbose
+    this.tty = tty
   }
 
   public async init(argv: string[]) {
     const args = mri(argv.slice(2))
     this.verbose = args.verbose ?? false
+    this.tty = JSON.parse(args.tty ?? 'true')
 
     const simulatePro = args['simulate-pro'] ?? false
     this.dev = simulatePro ? false : this.dev
+    this.test = simulatePro ? false : this.test
+    this.prod = simulatePro ? true : this.prod
   }
 
   public get appDir() {
@@ -35,10 +51,6 @@ class CLIConfig {
 
   public get latitudeJsonPath() {
     return path.join(this.rootDir, LATITUDE_CONFIG_FILE)
-  }
-
-  public get pro() {
-    return !this.dev
   }
 
   public get name() {
@@ -52,5 +64,7 @@ class CLIConfig {
 
 export default new CLIConfig({
   dev: process.env.NODE_ENV === 'development',
+  test: process.env.NODE_ENV === 'test',
+  prod: process.env.NODE_ENV === 'production',
   rootDir: process.cwd(),
 })

--- a/packages/cli/src/lib/installLatitudeServer.ts
+++ b/packages/cli/src/lib/installLatitudeServer.ts
@@ -7,5 +7,5 @@ export default function installLatitudeServer({
 }: {
   version?: string
 }) {
-  return config.pro ? cloneAppFromNpm({ version }) : symlinkAppFromLocal()
+  return config.prod ? cloneAppFromNpm({ version }) : symlinkAppFromLocal()
 }

--- a/packages/cli/src/lib/server/index.ts
+++ b/packages/cli/src/lib/server/index.ts
@@ -96,7 +96,7 @@ const options = ({ method = 'GET', path, headers }: Options) => {
 export const request = (opts: Options) => {
   return new Promise<{ response: IncomingMessage; body: string }>(
     (resolve, reject) => {
-      const httpModule = config.pro ? https : http
+      const httpModule = config.prod ? https : http
       const req = httpModule.request(options(opts), (res: IncomingMessage) => {
         let body = ''
 
@@ -133,7 +133,7 @@ export const request = (opts: Options) => {
 
 export const sseRequest = (opts: Options): Promise<IncomingMessage> => {
   return new Promise((resolve, reject) => {
-    const httpModule = config.pro ? https : http
+    const httpModule = config.prod ? https : http
     const req = httpModule.request(
       options({
         ...opts,

--- a/packages/cli/src/lib/telemetry/index.test.ts
+++ b/packages/cli/src/lib/telemetry/index.test.ts
@@ -1,31 +1,17 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import crypto from 'crypto'
-import telemetry, { Telemetry } from './index'
-import chalk from 'chalk'
 import os from 'os'
-
-const SELECT_ARGS = {
-  message:
-    '🌟 Help us make Latitude better for you by sharing anonymous usage data—it’s a simple way \n to contribute, with full control to opt-in or opt-out at any time.',
-  default: true,
-  choices: [
-    { value: true, name: 'Yes, count me in!' },
-    { value: false, name: 'No, maybe later' },
-  ],
-}
+import { Telemetry } from './index'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 process.env['PACKAGE_VERSION'] = '1.0.0'
+process.env.TELEMETRY_CLIENT_KEY = 'mocked-client-key'
+process.env.TELEMETRY_URL = 'mocked-url'
 
 vi.spyOn(os, 'platform').mockImplementation(() => 'darwin')
 vi.spyOn(os, 'release').mockImplementation(() => '20.6.0')
 
-const mockedCrypto = vi
-  .spyOn(crypto, 'randomBytes')
-  .mockImplementation(() => ({ toString: () => 'mocked-random-user-id' }))
-
 const mockedTrack = vi.hoisted(() => vi.fn())
 const mockedIdentify = vi.hoisted(() => vi.fn())
-const MockedRudderStack = vi.hoisted(() =>
+const mockedRudderStack = vi.hoisted(() =>
   vi.fn().mockImplementation((_clientKey, _options) => {
     return {
       track: mockedTrack,
@@ -33,21 +19,7 @@ const MockedRudderStack = vi.hoisted(() =>
     }
   }),
 )
-vi.mock('@rudderstack/rudder-sdk-node', () => ({
-  default: MockedRudderStack,
-}))
-
-const mockedStoreGet = vi.hoisted(() => vi.fn())
-const mockedStoreSet = vi.hoisted(() => vi.fn())
-const MockedConfigStore = vi.hoisted(() =>
-  vi.fn().mockImplementation((_pkgVersion, _options) => {
-    return {
-      set: mockedStoreSet,
-      get: mockedStoreGet,
-    }
-  }),
-)
-vi.mock('configstore', () => ({ default: MockedConfigStore }))
+vi.mock('@rudderstack/rudder-sdk-node', () => ({ default: mockedRudderStack }))
 
 const mockedSelect = vi.hoisted(() => vi.fn())
 vi.mock('@inquirer/prompts', async () => {
@@ -58,143 +30,103 @@ vi.mock('@inquirer/prompts', async () => {
   }
 })
 
+const mockedConfig = vi.hoisted(() => ({
+  dev: true,
+  tty: true,
+}))
 vi.mock('$src/config', () => ({
+  default: mockedConfig,
+}))
+
+const mockedStoreSet = vi.hoisted(() => vi.fn())
+const mockedStoreGet = vi.hoisted(() => vi.fn())
+vi.mock('$src/lib/configStore', () => ({
   default: {
-    dev: false,
+    set: mockedStoreSet,
+    get: mockedStoreGet,
   },
 }))
 
-const consoleMock = vi.spyOn(console, 'log').mockImplementation(() => undefined)
-
 describe('Telemetry', () => {
-  beforeEach(() => {
-    vi.stubEnv('TELEMETRY_CLIENT_KEY', 'secret-telemetry-key')
-    vi.stubEnv('TELEMETRY_URL', 'telemetry-url')
-    mockedStoreGet.mockReturnValue({
-      enabled: undefined,
-      anonymousUserId: undefined,
-    })
-  })
-
   afterEach(() => {
-    consoleMock.mockReset()
-    vi.unstubAllEnvs()
-  })
-
-  it('should create an instance', () => {
-    expect(telemetry).toBeInstanceOf(Telemetry)
-  })
-
-  it('initialize rudderstack', () => {
-    new Telemetry()
-    expect(MockedRudderStack).toHaveBeenCalledWith('secret-telemetry-key', {
-      dataPlaneUrl: 'telemetry-url',
-    })
-  })
-
-  describe('#showStatus', () => {
-    it('show status disabled', () => {
-      mockedStoreGet.mockReturnValue(false)
-      telemetry.showStatus()
-
-      expect(consoleMock).toHaveBeenLastCalledWith(
-        chalk.green('Telemetry is disabled'),
-      )
-    })
-
-    it('show status enabled', () => {
-      telemetry.showStatus()
-      expect(consoleMock).toHaveBeenLastCalledWith(
-        chalk.green('Telemetry is disabled'),
-      )
-    })
+    vi.clearAllMocks()
   })
 
   describe('#track', () => {
-    beforeEach(() => {
-      mockedSelect.mockClear()
-    })
-
-    afterEach(() => {
-      mockedSelect.mockReset()
-    })
-
-    it('does not ask for permission if already initialized', async () => {
-      telemetry['initialized'] = true
-      await telemetry.track({ event: 'startCommand' })
-
-      expect(mockedSelect).not.toHaveBeenCalled()
-      telemetry['initialized'] = false
-    })
-
     it('does not track the event if not enabled', async () => {
-      mockedStoreGet.mockReturnValue({
-        enabled: false,
-        anonymousUserId: undefined,
+      mockedStoreGet.mockImplementationOnce((key) => {
+        if (key === 'telemetry.enabled') return false
+        return undefined
       })
-      await telemetry.track({ event: 'startCommand' })
+
+      const instance = new Telemetry()
+      await instance.track({ event: 'startCommand' })
 
       expect(mockedTrack).not.toHaveBeenCalled()
     })
 
     it('ask for permission when startCommand is invoked', async () => {
-      await telemetry.track({ event: 'startCommand' })
+      mockedStoreGet.mockImplementationOnce((key) => {
+        if (key === 'telemetry.enabled') return undefined
+      })
 
-      expect(mockedSelect).toHaveBeenCalledWith(SELECT_ARGS)
+      const instance = new Telemetry()
+      await instance.track({ event: 'startCommand' })
+
+      expect(mockedSelect).toHaveBeenCalled()
     })
 
-    it('initialize config store', async () => {
-      await telemetry.track({ event: 'startCommand' })
-      expect(MockedConfigStore).toHaveBeenCalledWith(expect.any(String), {
-        telemetry: {
-          enabled: undefined,
-          anonymousUserId: undefined,
-        },
+    it('does not ask for permission when startCommand is invoked and permission is already granted', async () => {
+      mockedStoreGet.mockImplementationOnce((key) => {
+        if (key === 'telemetry.enabled') return true
       })
+
+      const instance = new Telemetry()
+      await instance.track({ event: 'startCommand' })
+
+      expect(mockedSelect).not.toHaveBeenCalled()
     })
 
     describe('when telemetry permission is not granted', () => {
       beforeEach(() => {
         mockedSelect.mockResolvedValue(false)
+        mockedStoreGet.mockReturnValueOnce(undefined).mockReturnValue(false)
+      })
+
+      it('emits a telemetrydisabled event', async () => {
+        const instance = new Telemetry()
+        await instance.track({ event: 'startCommand' })
+
+        expect(mockedTrack).toHaveBeenCalledWith({
+          anonymousId: expect.any(String),
+          event: 'telemetryDisabled',
+          properties: undefined,
+        })
       })
 
       it('identifies user', async () => {
         const instance = new Telemetry()
         await instance.track({ event: 'startCommand' })
 
-        expect(mockedIdentify).toHaveBeenCalledWith({
-          anonymousId: 'cli-mocked-random-user-id',
-          context: {
-            telemetry: { enabled: false },
-            cliVersion: '1.0.0',
-            operatingSystem: {
-              platform: 'darwin',
-              version: '20.6.0',
-            },
-          },
-        })
+        expect(mockedIdentify).toHaveBeenCalled()
       })
 
       it('stores config', async () => {
+        const telemetry = new Telemetry()
         await telemetry.track({ event: 'startCommand' })
         expect(mockedStoreSet).toHaveBeenCalledWith('telemetry.enabled', false)
         expect(mockedStoreSet).toHaveBeenCalledWith(
           'telemetry.anonymousUserId',
-          'mocked-random-user-id',
+          expect.any(String),
         )
       })
 
       it('tracks event', async () => {
+        const telemetry = new Telemetry()
         await telemetry.track({ event: 'startCommand' })
 
-        expect(mockedTrack).toHaveBeenCalledWith({
-          anonymousId: 'cli-mocked-random-user-id',
-          event: 'telemetryDisabled',
-          properties: undefined,
-        })
-
         expect(mockedTrack).not.toHaveBeenCalledWith({
-          anonymousId: 'cli-mocked-random-user-id',
+          anonymousId: expect.any(String),
           event: 'startCommand',
           properties: undefined,
         })
@@ -204,17 +136,27 @@ describe('Telemetry', () => {
     describe('when persimission is granted', () => {
       beforeEach(() => {
         mockedSelect.mockResolvedValue(true)
+        mockedStoreGet.mockReturnValueOnce(undefined).mockReturnValue(true)
+      })
+
+      it('emits a telemetryenabled event', async () => {
+        const instance = new Telemetry()
+        await instance.track({ event: 'startCommand' })
+
+        expect(mockedTrack).toHaveBeenCalledWith({
+          anonymousId: expect.any(String),
+          event: 'telemetryEnabled',
+          properties: undefined,
+        })
       })
 
       it('generates random identifier', async () => {
         const instance = new Telemetry()
         await instance.track({ event: 'startCommand' })
 
-        expect(mockedCrypto).toHaveBeenCalledWith(16)
-        expect(mockedStoreSet).toHaveBeenNthCalledWith(
-          1,
+        expect(mockedStoreSet).toHaveBeenCalledWith(
           'telemetry.anonymousUserId',
-          'mocked-random-user-id',
+          expect.any(String),
         )
       })
 
@@ -223,41 +165,58 @@ describe('Telemetry', () => {
         await instance.track({ event: 'startCommand' })
 
         expect(mockedIdentify).toHaveBeenCalledWith({
-          anonymousId: 'cli-mocked-random-user-id',
+          anonymousId: expect.any(String),
           context: {
-            telemetry: { enabled: true },
             cliVersion: '1.0.0',
             operatingSystem: {
               platform: 'darwin',
               version: '20.6.0',
+            },
+            telemetry: {
+              enabled: true,
             },
           },
         })
       })
 
       it('stores config', async () => {
-        await telemetry.track({ event: 'startCommand' })
+        const instance = new Telemetry()
+        await instance.track({ event: 'startCommand' })
+
         expect(mockedStoreSet).toHaveBeenCalledWith('telemetry.enabled', true)
         expect(mockedStoreSet).toHaveBeenCalledWith(
           'telemetry.anonymousUserId',
-          'mocked-random-user-id',
+          expect.any(String),
         )
       })
 
       it('tracks event', async () => {
-        await telemetry.track({ event: 'startCommand' })
+        const instance = new Telemetry()
+        await instance.track({ event: 'startCommand' })
 
         expect(mockedTrack).toHaveBeenCalledWith({
-          anonymousId: 'cli-mocked-random-user-id',
-          event: 'telemetryEnabled',
-          properties: undefined,
-        })
-
-        expect(mockedTrack).toHaveBeenCalledWith({
-          anonymousId: 'cli-mocked-random-user-id',
+          anonymousId: expect.any(String),
           event: 'startCommand',
           properties: undefined,
         })
+      })
+    })
+
+    describe('when tty is disabled', () => {
+      beforeEach(() => {
+        mockedConfig.tty = false
+      })
+
+      it('does not ask for permission when startCommand is invoked', async () => {
+        mockedStoreGet.mockImplementationOnce((key) => {
+          if (key === 'telemetry.enabled') return undefined
+        })
+
+        const telemetry = new Telemetry()
+        await telemetry.track({ event: 'startCommand' })
+
+        expect(mockedSelect).not.toHaveBeenCalled()
+        expect(mockedTrack).not.toHaveBeenCalled()
       })
     })
   })

--- a/packages/cli/src/templates/Dockerfile.ts
+++ b/packages/cli/src/templates/Dockerfile.ts
@@ -12,8 +12,7 @@ WORKDIR /usr/src/app
 COPY package.jso[n] .
 COPY latitude.json .
 
-RUN latitude telemetry --disable
-RUN latitude setup
+RUN latitude setup --tty false
 
 FROM builder AS runner
 
@@ -24,7 +23,7 @@ COPY --from=builder /usr/src/app/.latitude ./
 COPY --from=builder /usr/src/app/latitude.json ./latitude.json
 COPY . .
 
-RUN latitude build
+RUN latitude build --tty false
 
 WORKDIR /usr/src/app/build
 

--- a/packages/cli/src/templates/dockerignore.template
+++ b/packages/cli/src/templates/dockerignore.template
@@ -1,3 +1,4 @@
+.env
 .git*
 .latitude
 .env

--- a/packages/cli/tests/e2e/dev.cjs
+++ b/packages/cli/tests/e2e/dev.cjs
@@ -7,7 +7,9 @@ function dev () {
     'dev',
     '--open',
     'false',
-    '--verbose'
+    '--verbose',
+    '--tty',
+    false
   ], {
     cwd: './test-project',
   })

--- a/packages/cli/tests/e2e/start.cjs
+++ b/packages/cli/tests/e2e/start.cjs
@@ -1,18 +1,8 @@
 const dev = require('./dev.cjs')
 const path = require('path')
-const { spawn, spawnSync } = require('child_process')
+const { spawn } = require('child_process')
 
 let ok = false
-
-// Disable telemetry
-spawnSync(
-  'node',
-  [
-    path.join(__dirname, '../../dist/cli.js'),
-    'telemetry',
-    '--disable'
-  ]
-)
 
 const spawned = spawn('node', [
   path.join(__dirname, '../../dist/cli.js'),
@@ -21,7 +11,9 @@ const spawned = spawn('node', [
   'test-project',
   '--template',
   'default',
-  '--verbose'
+  '--verbose',
+  '--tty',
+  false
 ])
 
 spawned.stdout.pipe(process.stdout)


### PR DESCRIPTION
## Describe your changes
This allows the cli to run commands where user input is not expected. Of course it won't apply to use cases where user input is expected.

https://github.com/latitude-dev/latitude/assets/1948929/08d9841d-4b05-4ffc-869c-8674a068f330

## Checklist before requesting a review
- [x] I have added thorough tests
- [x] I have updated the documentation if necessary
- [x] I have added a human-readable description of the changes for the release notes
- [x] I have included a recorded video capture of the feature manually tested

