### PR TITLE
Fix: svelte package dev watch mode

### DIFF
--- a/packages/client/svelte/package.json
+++ b/packages/client/svelte/package.json
@@ -8,10 +8,11 @@
     "build:vite": "vite build",
     "build:css": "npx tailwindcss -i ./src/assets/app.css -o ./dist/styles.css",
     "buildAndPackage": "pnpm run build:vite && pnpm run package && pnpm run build:css",
-    "dev": "svelte-package --watch",
+    "build:svelte": "svelte-package -o dist/lib",
+    "dev": "concurrently \"pnpm run build:css --watch\" \"pnpm run build:svelte --watch\"",
     "dev:vite": "vite dev",
     "lint": "eslint . --max-warnings 0",
-    "package": "pnpm run prepare && svelte-package && publint",
+    "package": "pnpm run prepare && pnpm run build:svelte  && publint",
     "prepare": "svelte-kit sync",
     "prettier": "prettier --write src/**/*.ts src/**/*.svelte",
     "storybook": "storybook dev -p 6006",
@@ -22,14 +23,14 @@
   "exports": {
     "./tailwind.preset": "./tailwind.config.js",
     "./internal": {
-      "types": "./dist/internal/index.d.ts",
-      "svelte": "./dist/internal/index.js",
-      "default": "./dist/internal/index.js"
+      "types": "./dist/lib/internal/index.d.ts",
+      "svelte": "./dist/lib/internal/index.js",
+      "default": "./dist/lib/internal/index.js"
     },
     ".": {
-      "types": "./dist/index.d.ts",
-      "svelte": "./dist/index.js",
-      "default": "./dist/index.js"
+      "types": "./dist/lib/index.d.ts",
+      "svelte": "./dist/lib/index.js",
+      "default": "./dist/lib/index.js"
     },
     "./styles.css": "./dist/styles.css"
   },
@@ -85,6 +86,7 @@
     "@sveltejs/vite-plugin-svelte": "^3.0.0",
     "@types/echarts": "^4.9.22",
     "@types/eslint": "8.56.0",
+    "concurrently": "^8.2.2",
     "eslint-plugin-storybook": "^0.6.15",
     "prettier": "^3.1.1",
     "prettier-plugin-svelte": "^3.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -692,6 +692,9 @@ importers:
       '@types/eslint':
         specifier: 8.56.0
         version: 8.56.0
+      concurrently:
+        specifier: ^8.2.2
+        version: 8.2.2
       eslint-plugin-storybook:
         specifier: ^0.6.15
         version: 0.6.15(eslint@8.57.0)(typescript@5.3.3)
@@ -9161,7 +9164,7 @@ packages:
     peerDependencies:
       '@sveltejs/kit': ^2.0.0
     dependencies:
-      '@sveltejs/kit': 2.5.0(@sveltejs/vite-plugin-svelte@3.0.0)(svelte@4.2.7)(vite@5.0.12)
+      '@sveltejs/kit': 2.5.0(@sveltejs/vite-plugin-svelte@3.0.0)(svelte@4.2.10)(vite@5.0.12)
       import-meta-resolve: 4.0.0
     dev: true
 
@@ -12360,6 +12363,22 @@ packages:
     resolution: {integrity: sha512-4gEjHJFT9e+2W/77h/DS5SGUgwDaOwprX8L/gl5+3ixnzkVJJsZWDSelmN3Oilw3LNDZjZV0yqH1hLG3k6nghg==}
     dependencies:
       source-map: 0.6.1
+    dev: true
+
+  /concurrently@8.2.2:
+    resolution: {integrity: sha512-1dP4gpXFhei8IOtlXRE/T/4H88ElHgTiUzh71YUmtjTEHMSRS2Z/fgOxHSxxusGHogsRfxNq1vyAwxSC+EVyDg==}
+    engines: {node: ^14.13.0 || >=16.0.0}
+    hasBin: true
+    dependencies:
+      chalk: 4.1.2
+      date-fns: 2.30.0
+      lodash: 4.17.21
+      rxjs: 7.8.1
+      shell-quote: 1.8.1
+      spawn-command: 0.0.2
+      supports-color: 8.1.1
+      tree-kill: 1.2.2
+      yargs: 17.7.2
     dev: true
 
   /config-chain@1.1.13:
@@ -21080,6 +21099,12 @@ packages:
     dependencies:
       queue-microtask: 1.2.3
 
+  /rxjs@7.8.1:
+    resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
+    dependencies:
+      tslib: 2.6.2
+    dev: true
+
   /sade@1.8.1:
     resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
     engines: {node: '>=6'}
@@ -21306,6 +21331,10 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  /shell-quote@1.8.1:
+    resolution: {integrity: sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==}
+    dev: true
+
   /side-channel@1.0.4:
     resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
     dependencies:
@@ -21531,6 +21560,10 @@ packages:
 
   /space-separated-tokens@1.1.5:
     resolution: {integrity: sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==}
+    dev: true
+
+  /spawn-command@0.0.2:
+    resolution: {integrity: sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==}
     dev: true
 
   /spawndamnit@2.0.0:
@@ -22715,6 +22748,11 @@ packages:
     engines: {node: '>=18'}
     dependencies:
       punycode: 2.3.1
+    dev: true
+
+  /tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
     dev: true
 
   /trim-newlines@3.0.1:


### PR DESCRIPTION
## Describe your changes

During the build process of our client/svelte package, the `build:css` process is executed, which compiles the tailwind styles into the `dist/styles.css` files, which is necessary for this package to be correctly imported.

Running the development environment of this package with `pnpm dev` breaks the exported files. This is because the dev mode runs `svelte-package --watch`, which rebuild the svelte package each time a svelte file changes. The problem with this is that, to rebuild it, it first removes all contents of the dist file, including `dist/styles.css`, but does not compile tailwind again afterwards.

Additionally, `build:css` is also called in watch mode, to update the styles file automatically too.
