### PR TITLE
Fix: Properly handle object properties on Query Compiler

### DIFF
--- a/.changeset/nasty-spies-argue.md
+++ b/.changeset/nasty-spies-argue.md
@@ -1,0 +1,8 @@
+---
+"@latitude-data/sql-compiler": minor
+---
+
+Improved handling of object properties in query logic blocks. Now you can:
+ - Invoke methods from objects.
+ - Modify object properties.
+ - Access properties using optional chaining (the `?.` operator).

--- a/packages/connectors/compiler/src/compiler/compiler.test.ts
+++ b/packages/connectors/compiler/src/compiler/compiler.test.ts
@@ -7,8 +7,8 @@ const compileQuery = (query: string) => {
   return compile({
     query,
     resolveFn: async (value: unknown): Promise<string> => `$[[${value}]]`,
-    supportedMethods: {},
     configFn,
+    supportedMethods: {},
   })
 }
 
@@ -70,8 +70,8 @@ describe('parameterisation of interpolated values', async () => {
     const result = await compile({
       query: sql,
       resolveFn,
-      supportedMethods: {},
       configFn,
+      supportedMethods: {},
     })
 
     const matches = result.match(/\[\d+\]/g) || [] // resolved values in order of appearance in the string
@@ -128,6 +128,69 @@ describe('variable assignment', async () => {
     const result = await compileQuery(sql)
 
     expect(result).toBe('$[[7]]')
+  })
+
+  it('can update nested values', async () => {
+    const sql = `
+      {foo = { a: 1, b: 2 }}
+      {foo.a += 2}
+      {foo.b += 3}
+      {foo.a} {foo.b}
+    `
+    const result = await compileQuery(sql)
+
+    expect(result).toBe('$[[3]] $[[5]]')
+  })
+
+  it('fails when nested value does not exist', async () => {
+    const sql = `
+      {foo = { a: 1, b: 2 }}
+      {foo.c += 2}
+      {foo.c}
+    `
+    const action = () => compileQuery(sql)
+    const error = await getExpectedError(action, CompileError)
+    expect(error.code).toBe('property-not-exists')
+  })
+
+  it('does not allow optional chaining operator', async () => {
+    const sql = `
+      {foo = { a: 1, b: 2 }}
+      {foo?.a = 2}
+    `
+    const action = () => compileQuery(sql)
+    const error = await getExpectedError(action, CompileError)
+    expect(error.code).toBe('parse-error') // Requirement is already implemented in the parser
+  })
+
+  it('allow reassigning elements in an array', async () => {
+    const sql = `
+      {foo = [1, 2, 3, 4, 5, 6]}
+      {foo[3] = 'bar'}
+
+      {foo}
+    `
+
+    const result = await compileQuery(sql)
+    expect(result).toBe('$[[1,2,3,bar,5,6]]')
+  })
+
+  it('can modify variables with update operators', async () => {
+    const sql1 = '{foo = 0} {foo++} {foo}'
+    const sql2 = '{foo = 0} {++foo} {foo}'
+
+    const result1 = await compileQuery(sql1)
+    const result2 = await compileQuery(sql2)
+
+    expect(result1).toBe('$[[0]] $[[1]]')
+    expect(result2).toBe('$[[1]] $[[1]]')
+  })
+
+  it('fails when trying to update a variable that is not a number', async () => {
+    const sql = '{foo = "bar"} {++foo}'
+    const action = () => compileQuery(sql)
+    const error = await getExpectedError(action, CompileError)
+    expect(error.code).toBe('invalid-update')
   })
 })
 
@@ -459,7 +522,7 @@ describe('custom methods', async () => {
     expect(result).toBe('$[[5]]')
   })
 
-  it('shows the correct error message when a method fails', async () => {
+  it('shows the correct error message when a named method fails', async () => {
     const sql = '{fooFn()}'
     const action = () =>
       compile({
@@ -475,5 +538,189 @@ describe('custom methods', async () => {
     const error = await getExpectedError(action, CompileError)
     expect(error.code).toBe('function-call-error')
     expect(error.message).toBe("Error calling function 'fooFn': \nError bar")
+  })
+})
+
+describe('variable member access', async () => {
+  it('correctly evaluates member access', async () => {
+    const sql = `
+      {foo = { bar: 'val' } }
+      {foo.bar}
+    `
+    const result = await compileQuery(sql)
+    expect(result).toBe('$[[val]]')
+  })
+
+  it('allows optional chaining operator', async () => {
+    const sql1 = `
+      {foo = { bar: 'val' } }
+      {foo?.bar}
+    `
+    const sql2 = `
+      {foo = undefined() }
+      {foo?.bar}
+    `
+
+    function compileQuery(sql: string) {
+      return compile({
+        query: sql,
+        resolveFn: async (value: unknown): Promise<string> => `$[[${value}]]`,
+        configFn,
+        supportedMethods: {
+          undefined: async <T extends boolean>(): Promise<
+            T extends true ? string : unknown
+          > => {
+            return undefined as T extends true ? string : unknown
+          },
+        },
+      })
+    }
+
+    const result1 = await compileQuery(sql1)
+    const result2 = await compileQuery(sql2)
+
+    expect(result1).toBe('$[[val]]')
+    expect(result2).toBe('$[[undefined]]')
+  })
+
+  it('runs methods from variables', async () => {
+    const nowDate = new Date()
+
+    const sql = `
+      {currentTime = now()}
+      {currentTime.toISOString()}
+    `
+
+    const result = await compile({
+      query: sql,
+      resolveFn: async (value: unknown): Promise<string> => `$[[${value}]]`,
+      configFn,
+      supportedMethods: {
+        now: async <T extends boolean>(): Promise<
+          T extends true ? string : unknown
+        > => {
+          return nowDate as T extends true ? string : unknown
+        },
+      },
+    })
+
+    const expectedString = nowDate.toISOString()
+    expect(result).toBe(`$[[${expectedString}]]`)
+  })
+
+  it('fails when trying to run non-function methods', async () => {
+    const sql = `
+      {foo = 'bar'}
+      {foo.bar()}
+    `
+
+    const action = () => compileQuery(sql)
+    const error = await getExpectedError(action, CompileError)
+    expect(error.code).toBe('not-a-function')
+  })
+})
+
+describe('variable member access', async () => {
+  it('correctly evaluates member access', async () => {
+    const sql = `
+      {foo = { bar: 'val' } }
+      {foo.bar}
+    `
+    const result = await compileQuery(sql)
+    expect(result).toBe('$[[val]]')
+  })
+
+  it('allows optional chaining operator', async () => {
+    const sql1 = `
+      {foo = { bar: 'val' } }
+      {foo?.bar}
+    `
+    const sql2 = `
+      {foo = undefined() }
+      {foo?.bar}
+    `
+
+    function compileQuery(sql: string) {
+      return compile({
+        query: sql,
+        resolveFn: async (value: unknown): Promise<string> => `$[[${value}]]`,
+        configFn,
+        supportedMethods: {
+          undefined: async <T extends boolean>(): Promise<
+            T extends true ? string : unknown
+          > => {
+            return undefined as T extends true ? string : unknown
+          },
+        },
+      })
+    }
+
+    const result1 = await compileQuery(sql1)
+    const result2 = await compileQuery(sql2)
+
+    expect(result1).toBe('$[[val]]')
+    expect(result2).toBe('$[[undefined]]')
+  })
+
+  it('runs methods from variables', async () => {
+    const nowDate = new Date()
+
+    const sql = `
+      {currentTime = now()}
+      {currentTime.toISOString()}
+    `
+
+    const result = await compile({
+      query: sql,
+      resolveFn: async (value: unknown): Promise<string> => `$[[${value}]]`,
+      configFn,
+      supportedMethods: {
+        now: async <T extends boolean>(): Promise<
+          T extends true ? string : unknown
+        > => {
+          return nowDate as T extends true ? string : unknown
+        },
+      },
+    })
+
+    const expectedString = nowDate.toISOString()
+    expect(result).toBe(`$[[${expectedString}]]`)
+  })
+
+  it('fails when trying to run non-function methods', async () => {
+    const sql = `
+      {foo = 'bar'}
+      {foo.bar()}
+    `
+
+    const action = () => compileQuery(sql)
+    const error = await getExpectedError(action, CompileError)
+    expect(error.code).toBe('not-a-function')
+  })
+
+  it('shows the correct error message when a varaible method fails', async () => {
+    const sql = `
+      {foo = getFoo()}
+      {foo.bar()}
+    `
+
+    const action = () =>
+      compile({
+        query: sql,
+        resolveFn: async (value: unknown): Promise<string> => `$[[${value}]]`,
+        configFn,
+        supportedMethods: {
+          getFoo: async <T extends boolean>() =>
+            ({
+              bar: () => {
+                throw new Error('baz')
+              },
+            }) as T extends true ? string : unknown,
+        },
+      })
+
+    const error = await getExpectedError(action, CompileError)
+    expect(error.code).toBe('function-call-error')
+    expect(error.message).toBe('Error calling function: \nError baz')
   })
 })

--- a/packages/connectors/compiler/src/compiler/index.ts
+++ b/packages/connectors/compiler/src/compiler/index.ts
@@ -294,63 +294,6 @@ export class Compiler {
       return UNARY_OPERATOR_METHODS[unaryOperator]?.(unaryArgument, unaryPrefix)
     }
 
-    if (node.type === 'AssignmentExpression') {
-      const assignedVariableName = (node.left as Identifier).name
-      let assignedValue = await this.resolveLogicNodeExpression(
-        node.right,
-        localScope,
-      )
-      const assignmentOperator = node.operator
-
-      if (assignmentOperator != '=') {
-        if (!(assignmentOperator in ASSIGNMENT_OPERATOR_METHODS)) {
-          this.expressionError(
-            errors.unsupportedOperator(assignmentOperator),
-            node,
-          )
-        }
-        if (!localScope.exists(assignedVariableName)) {
-          this.expressionError(
-            errors.variableNotDeclared(assignedVariableName),
-            node,
-          )
-        }
-        assignedValue = ASSIGNMENT_OPERATOR_METHODS[assignmentOperator]?.(
-          localScope.get(assignedVariableName),
-          assignedValue,
-        )
-      }
-      if (localScope.isConst(assignedVariableName)) {
-        this.expressionError(errors.constantReassignment, node)
-      }
-      localScope.set(assignedVariableName, assignedValue)
-      return assignedValue
-    }
-
-    if (node.type === 'UpdateExpression') {
-      const updateOperator = node.operator
-      if (!['++', '--'].includes(updateOperator)) {
-        this.expressionError(errors.unsupportedOperator(updateOperator), node)
-      }
-      const updatedVariableName = (node.argument as Identifier).name
-      if (!localScope.exists(updatedVariableName)) {
-        this.expressionError(
-          errors.variableNotDeclared(updatedVariableName),
-          node,
-        )
-      }
-      if (localScope.isConst(updatedVariableName)) {
-        this.expressionError(errors.constantReassignment, node)
-      }
-      const originalValue = localScope.get(updatedVariableName)
-      const updatedValue =
-        updateOperator === '++'
-          ? (originalValue as number) + 1
-          : (originalValue as number) - 1
-      localScope.set(updatedVariableName, updatedValue)
-      return node.prefix ? updatedValue : originalValue
-    }
-
     if (node.type === 'MemberExpression') {
       const object = (await this.resolveLogicNodeExpression(
         node.object,
@@ -359,9 +302,140 @@ export class Compiler {
         [key: string]: any
       }
       const property = node.computed
-        ? await this.resolveLogicNodeExpression(node.property, localScope)
+        ? ((await this.resolveLogicNodeExpression(
+            node.property,
+            localScope,
+          )) as string)
         : (node.property as Identifier).name
+
+      const isOptional = node.optional
+      if (object == null && isOptional) return undefined
+
       return MEMBER_EXPRESSION_METHOD(object, property)
+    }
+
+    if (node.type === 'AssignmentExpression') {
+      const assignmentOperator = node.operator
+      if (!(assignmentOperator in ASSIGNMENT_OPERATOR_METHODS)) {
+        this.expressionError(
+          errors.unsupportedOperator(assignmentOperator),
+          node,
+        )
+      }
+      const assignmentMethod = ASSIGNMENT_OPERATOR_METHODS[assignmentOperator]!
+
+      const assignmentValue = await this.resolveLogicNodeExpression(
+        node.right,
+        localScope,
+      )
+
+      if (node.left.type === 'Identifier') {
+        const assignedVariableName = (node.left as Identifier).name
+
+        if (localScope.isConst(assignedVariableName)) {
+          this.expressionError(errors.constantReassignment, node)
+        }
+
+        if (
+          assignmentOperator != '=' &&
+          !localScope.exists(assignedVariableName)
+        ) {
+          this.expressionError(
+            errors.variableNotDeclared(assignedVariableName),
+            node,
+          )
+        }
+
+        const updatedValue = assignmentMethod(
+          localScope.exists(assignedVariableName)
+            ? localScope.get(assignedVariableName)
+            : undefined,
+          assignmentValue,
+        )
+
+        localScope.set(assignedVariableName, updatedValue)
+        return updatedValue
+      }
+      if (node.left.type === 'MemberExpression') {
+        const object = (await this.resolveLogicNodeExpression(
+          node.left.object,
+          localScope,
+        )) as { [key: string]: any }
+
+        const property = node.left.computed
+          ? ((await this.resolveLogicNodeExpression(
+              node.left.property,
+              localScope,
+            )) as string)
+          : (node.left.property as Identifier).name
+
+        if (assignmentOperator != '=' && !(property in object)) {
+          this.expressionError(errors.propertyNotExists(property), node)
+        }
+
+        const originalValue = object[property]
+        const updatedValue = assignmentMethod(originalValue, assignmentValue)
+        object[property] = updatedValue
+        return updatedValue
+      }
+
+      this.expressionError(errors.invalidAssignment, node)
+    }
+
+    if (node.type === 'UpdateExpression') {
+      const updateOperator = node.operator
+      if (!['++', '--'].includes(updateOperator)) {
+        this.expressionError(errors.unsupportedOperator(updateOperator), node)
+      }
+
+      if (node.argument.type == 'Identifier') {
+        const updatedVariableName = (node.argument as Identifier).name
+        if (!localScope.exists(updatedVariableName)) {
+          this.expressionError(
+            errors.variableNotDeclared(updatedVariableName),
+            node,
+          )
+        }
+        if (localScope.isConst(updatedVariableName)) {
+          this.expressionError(errors.constantReassignment, node)
+        }
+        const originalValue = localScope.get(updatedVariableName)
+        if (typeof originalValue !== 'number') {
+          this.expressionError(
+            errors.invalidUpdate(updateOperator, typeof originalValue),
+            node,
+          )
+        }
+        const updatedValue =
+          updateOperator === '++'
+            ? (originalValue as number) + 1
+            : (originalValue as number) - 1
+        localScope.set(updatedVariableName, updatedValue)
+        return node.prefix ? updatedValue : originalValue
+      }
+      if (node.argument.type == 'MemberExpression') {
+        const object = (await this.resolveLogicNodeExpression(
+          node.argument.object,
+          localScope,
+        )) as { [key: string]: any }
+
+        const property = node.argument.computed
+          ? ((await this.resolveLogicNodeExpression(
+              node.argument.property,
+              localScope,
+            )) as string)
+          : (node.argument.property as Identifier).name
+
+        const originalValue = object[property]
+        const updatedValue =
+          updateOperator === '++'
+            ? (originalValue as number) + 1
+            : (originalValue as number) - 1
+        object[property] = updatedValue
+        return node.prefix ? updatedValue : originalValue
+      }
+
+      this.expressionError(errors.invalidAssignment, node)
     }
 
     if (node.type === 'ConditionalExpression') {
@@ -379,6 +453,10 @@ export class Compiler {
 
     if (node.type === 'CallExpression') {
       return await this.handleFunction(node, false, localScope)
+    }
+
+    if (node.type === 'ChainExpression') {
+      return await this.resolveLogicNodeExpression(node.expression, localScope)
     }
 
     if (node.type === 'NewExpression') {
@@ -446,6 +524,25 @@ export class Compiler {
     interpolation: T,
     localScope: Scope,
   ): Promise<T extends true ? string : unknown> => {
+    if (node.callee.type === 'Identifier') {
+      return await this.handleSupportedMethod(node, interpolation, localScope)
+    }
+
+    if (node.callee.type === 'MemberExpression') {
+      const result = await this.handleMethodFromCallExpression(node, localScope)
+      if (!interpolation) return result as T extends true ? string : unknown
+      if (result === undefined) return '' // Method was a void
+      return await this.resolveFn(result)
+    }
+
+    this.expressionError(errors.unknownFunction(''), node)
+  }
+
+  private handleSupportedMethod = async <T extends boolean>(
+    node: SimpleCallExpression,
+    interpolation: T,
+    localScope: Scope,
+  ): Promise<T extends true ? string : unknown> => {
     const methodName = (node.callee as Identifier).name
     if (!(methodName in this.supportedMethods)) {
       this.expressionError(errors.unknownFunction(methodName), node)
@@ -466,8 +563,35 @@ export class Compiler {
       return returnedValue
     } catch (error: unknown) {
       if (error instanceof CompileError) throw error
+      this.expressionError(
+        errors.namedFunctionCallError(methodName, error),
+        node,
+      )
+    }
+  }
 
-      this.expressionError(errors.functionCallError(methodName, error), node)
+  private handleMethodFromCallExpression = async (
+    node: SimpleCallExpression,
+    localScope: Scope,
+  ): Promise<unknown> => {
+    const method = await this.resolveLogicNodeExpression(
+      node.callee,
+      localScope,
+    )
+    const args: unknown[] = []
+    for (const arg of node.arguments) {
+      args.push(await this.resolveLogicNodeExpression(arg, localScope))
+    }
+
+    if (typeof method !== 'function') {
+      this.expressionError(errors.notAFunction(typeof method), node)
+    }
+
+    try {
+      return await method(...args)
+    } catch (error: unknown) {
+      if (error instanceof CompileError) throw error
+      this.expressionError(errors.unnamedFunctionCallError(error), node)
     }
   }
 }

--- a/packages/connectors/compiler/src/compiler/operators.ts
+++ b/packages/connectors/compiler/src/compiler/operators.ts
@@ -45,22 +45,28 @@ export const UNARY_OPERATOR_METHODS: {
 }
 
 // https://github.com/estree/estree/blob/master/es5.md#memberexpression
-export const MEMBER_EXPRESSION_METHOD = (object: any, property: any): unknown =>
-  object[property]
+export const MEMBER_EXPRESSION_METHOD = (
+  object: any,
+  property: any,
+): unknown => {
+  const value = object[property]
+  return typeof value === 'function' ? value.bind(object) : value
+}
 
 // https://github.com/estree/estree/blob/master/es5.md#assignmentexpression
 export const ASSIGNMENT_OPERATOR_METHODS: {
   [operator: string]: (left: any, right: any) => unknown
 } = {
-  '+=': (left, right) => (left += right),
-  '-=': (left, right) => (left -= right),
-  '*=': (left, right) => (left *= right),
-  '/=': (left, right) => (left /= right),
-  '%=': (left, right) => (left %= right),
-  '<<=': (left, right) => (left <<= right),
-  '>>=': (left, right) => (left >>= right),
-  '>>>=': (left, right) => (left >>>= right),
-  '|=': (left, right) => (left |= right),
-  '^=': (left, right) => (left ^= right),
-  '&=': (left, right) => (left &= right),
+  '=': (_, right) => right,
+  '+=': (left, right) => left + right,
+  '-=': (left, right) => left - right,
+  '*=': (left, right) => left * right,
+  '/=': (left, right) => left / right,
+  '%=': (left, right) => left % right,
+  '<<=': (left, right) => left << right,
+  '>>=': (left, right) => left >> right,
+  '>>>=': (left, right) => left >>> right,
+  '|=': (left, right) => left | right,
+  '^=': (left, right) => left ^ right,
+  '&=': (left, right) => left & right,
 }

--- a/packages/connectors/compiler/src/error/errors.ts
+++ b/packages/connectors/compiler/src/error/errors.ts
@@ -107,16 +107,41 @@ export default {
     code: 'constant-reassignment',
     message: 'Cannot reassign a constant',
   },
+  invalidAssignment: {
+    code: 'invalid-assignment',
+    message: 'Invalid assignment',
+  },
+  invalidUpdate: (operation: string, type: string) => ({
+    code: 'invalid-update',
+    message: `Cannot use ${operation} operation on ${type}`,
+  }),
+
+  propertyNotExists: (property: string) => ({
+    code: 'property-not-exists',
+    message: `Property '${property}' does not exist on object`,
+  }),
   unknownFunction: (name: string) => ({
     code: 'unknown-function',
     message: `Unknown function: ${name}`,
   }),
-  functionCallError: (name: string, err: unknown) => {
+  notAFunction: (objectType: string) => ({
+    code: 'not-a-function',
+    message: `Object '${objectType}' is callable`,
+  }),
+  namedFunctionCallError: (name: string, err: unknown) => {
     const error = err as Error
     const errorKlassName = getKlassName(error)
     return {
       code: 'function-call-error',
       message: `Error calling function '${name}': \n${errorKlassName} ${error.message}`,
+    }
+  },
+  unnamedFunctionCallError: (err: unknown) => {
+    const error = err as Error
+    const errorKlassName = getKlassName(error)
+    return {
+      code: 'function-call-error',
+      message: `Error calling function: \n${errorKlassName} ${error.message}`,
     }
   },
   invalidFunctionResultInterpolation: {


### PR DESCRIPTION
## Describe your changes
Compiler did not properly handle object properties. Before this commit, you could not:
- Invoke object properties as methods
- Modify object properties values
- Allow optional chaining operator (`?.`)

### Invoke object properties as methods
Some variable types can contain functions that may be useful in the query compilation run-time. A clear example is Dates, where a Date can be passed to a query as a param, and we may want to run date-related methods.

```
{minDate = param('start_date')}  -- Returns a Date object

SELECT *
FROM table
WHERE year >= {minDate.getYear()}   -- You can now run the .getYear() method from the date object!
```

### Modify object properties as methods
You can now also modify the value from object properties such as arrays and hashes.

```
{ results = runQuery('other_query') }
{ results[0].name = 'foo' }  -- Modifying a property from an object

SELECT *
FROM table
WHERE name IN {#each results as row} {row.name} {/each}
```

### Allow optional chaining operator (`?.`)
The optional chaining operator allows you to read the value of a property located deep within a chain of connected objects without having to expressly validate that each reference in the chain is valid.

```
{ results = runQuery('other_query') }

SELECT *
FROM table
WHERE name = {results[0]?.name ?? 'default'}  -- If there are no results, it will return 'default'
```


## Checklist before requesting a review
- [x] I have added thorough tests
- [x] I have updated the documentation if necessary
- [x] I have added a human-readable description of the changes for the release notes
- [ ] I have included a recorded video capture of the feature manually tested

