### PR TITLE
feature: CLI update command updates dockerfiles

### DIFF
--- a/.changeset/seven-beans-cover.md
+++ b/.changeset/seven-beans-cover.md
@@ -1,0 +1,5 @@
+---
+"@latitude-data/cli": patch
+---
+
+update CLI command overrides docker config with new config

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -51,10 +51,6 @@ CLI.command('start')
 
 CLI.command('update')
   .describe('Update latitude app. You can define the version with --version')
-  .option(
-    '--force',
-    'Forces update of dockerignore and Dockerfile files to the latest version',
-  )
   .option('--fix', 'Installs the version defined in latitude.json')
   .option(
     '--next',

--- a/packages/cli/src/commands/update/index.ts
+++ b/packages/cli/src/commands/update/index.ts
@@ -70,13 +70,8 @@ async function getVersions({
   }
 }
 
-async function updateCommand(args: {
-  fix?: boolean
-  force?: boolean
-  next?: boolean
-}) {
+async function updateCommand(args: { fix?: boolean; next?: boolean }) {
   const fix = args.fix ?? false
-  const force = args.force ?? false
   const next = args.next ?? false
   const { oldVersion, newVersion } = await getVersions({ next, fix })
 
@@ -87,7 +82,7 @@ async function updateCommand(args: {
     properties: { fixingVersion: fix, oldVersion, newVersion },
   })
 
-  return updateApp({ version: newVersion, force })
+  return updateApp({ version: newVersion })
 }
 
 export default setRootDir(updateCommand)

--- a/packages/cli/src/lib/addDockerfiles/fromUpdate.test.ts
+++ b/packages/cli/src/lib/addDockerfiles/fromUpdate.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import chalk from 'chalk'
 import { existsSync } from 'fs'
 import { writeFile } from './_shared'
 import { addDockerfiles } from './fromUpdate'
@@ -37,20 +36,9 @@ describe('addDockerfiles', () => {
     })
   })
 
-  it('should not add .dockerignore or Dockerfile if they exist and force is false', () => {
+  it('should add .dockerignore and Dockerfile even if they exist', () => {
     vi.mocked(existsSync).mockReturnValue(true)
     addDockerfiles()
-    expect(writeFile).not.toHaveBeenCalled()
-    expect(console.log).toHaveBeenCalledWith(
-      chalk.yellow(
-        'Dockerignore file already exists. Run latitude update --force to update it.',
-      ),
-    )
-  })
-
-  it('should add .dockerignore and Dockerfile even if they exist when force is true', () => {
-    vi.mocked(existsSync).mockReturnValue(true)
-    addDockerfiles({ force: true })
     expect(writeFile).toHaveBeenCalledTimes(2)
   })
 })

--- a/packages/cli/src/lib/addDockerfiles/fromUpdate.ts
+++ b/packages/cli/src/lib/addDockerfiles/fromUpdate.ts
@@ -1,40 +1,20 @@
-import chalk from 'chalk'
 import config from '$src/config'
 import path from 'path'
-import { existsSync } from 'fs'
 import { writeFile } from './_shared'
 
-function addDockerignore(force = false) {
+function addDockerignore() {
   const dockerignorePath = path.resolve(config.rootDir, '.dockerignore')
-  if (!force && existsSync(dockerignorePath)) {
-    console.log(
-      chalk.yellow(
-        'Dockerignore file already exists. Run latitude update --force to update it.',
-      ),
-    )
-    return
-  }
 
   writeFile({ type: 'dockerignore', path: dockerignorePath })
 }
 
-function addDockerfile(force = false) {
+function addDockerfile() {
   const dockerfilePath = path.resolve(config.rootDir, 'Dockerfile')
-  if (!force && existsSync(dockerfilePath)) {
-    console.log(
-      chalk.yellow(
-        'Dockerfile file already exists. Run latitude update --force to update it.',
-      ),
-    )
-    return
-  }
 
   writeFile({ type: 'dockerfile', path: dockerfilePath })
 }
 
-export function addDockerfiles(
-  { force = false }: { force: boolean } = { force: false },
-) {
-  addDockerignore(force)
-  addDockerfile(force)
+export function addDockerfiles() {
+  addDockerignore()
+  addDockerfile()
 }

--- a/packages/cli/src/lib/updateApp/index.ts
+++ b/packages/cli/src/lib/updateApp/index.ts
@@ -26,16 +26,10 @@ async function updateConfigFile({ version }: { version: string }) {
   }
 }
 
-export default async function updateApp({
-  version,
-  force = false,
-}: {
-  version: string
-  force: boolean
-}) {
+export default async function updateApp({ version }: { version: string }) {
   await updateConfigFile({ version })
   await installLatitudeServer({ version })
   await installDependencies()
   addPackageJson()
-  addDockerfiles({ force })
+  addDockerfiles()
 }


### PR DESCRIPTION
## Describe your changes

Until now you had to pass a --force flag to update command in order to update docker-related config files. This was done to protect users' docker configs but in truth most people shouldn't be touching the docker configuration and it's a pita to have to pass this flag every time there's an update.

https://github.com/latitude-dev/latitude/assets/1948929/d9d0a79c-972c-4904-872d-fe1043170009

## Checklist before requesting a review
- [x] I have added thorough tests
- [x] I have updated the documentation if necessary
- [x] I have added a human-readable description of the changes for the release notes
- [x] I have included a recorded video capture of the feature manually tested (noop)

