### PR TITLE
Feature/latitude views theming

### DIFF
--- a/.changeset/clever-moles-prove.md
+++ b/.changeset/clever-moles-prove.md
@@ -1,0 +1,5 @@
+---
+"@latitude-data/react": minor
+---
+
+The LatitudeProvider now accepts a "mode" prop to define the color mode of the theme (light / dark / system)

--- a/.changeset/gorgeous-bugs-look.md
+++ b/.changeset/gorgeous-bugs-look.md
@@ -1,0 +1,5 @@
+---
+"@latitude-data/client": patch
+---
+
+Changed the generated css class from 'dark' to 'lat-dark' to avoid conflicts with other user-defined classes

--- a/.changeset/large-apes-stare.md
+++ b/.changeset/large-apes-stare.md
@@ -1,0 +1,5 @@
+---
+"@latitude-data/cli": minor
+---
+
+latitude.json is now copied and updated into the .latitude/app folder of the project

--- a/.changeset/popular-poems-wink.md
+++ b/.changeset/popular-poems-wink.md
@@ -1,0 +1,5 @@
+---
+"@latitude-data/svelte": minor
+---
+
+Svelte package now allows for custom themes and color modes into the ThemeProvider

--- a/.changeset/six-drinks-float.md
+++ b/.changeset/six-drinks-float.md
@@ -1,0 +1,5 @@
+---
+"@latitude-data/server": minor
+---
+
+latitude.json now accepts "theme" and "themeMode" attributes to customize the look and feel of the project views

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -19,12 +19,12 @@
     "query": "vite-node scripts/run_query/index.ts"
   },
   "devDependencies": {
-    "@latitude-data/test-connector": "workspace:^",
     "@latitude-data/client": "workspace:*",
     "@latitude-data/eslint-config": "workspace:*",
     "@latitude-data/query_result": "workspace:*",
     "@latitude-data/sql-compiler": "workspace:^",
     "@latitude-data/sveltekit-autoimport": "^1.7.1",
+    "@latitude-data/test-connector": "workspace:^",
     "@rollup/pluginutils": "^5.1.0",
     "@sveltejs/adapter-auto": "^3.0.0",
     "@sveltejs/adapter-node": "^4.0.1",
@@ -38,7 +38,6 @@
     "@types/uuid": "^9.0.8",
     "autoprefixer": "^10.4.17",
     "blessed": "^0.1.81",
-    "chokidar": "^3.5.3",
     "jsdom": "^24.0.0",
     "mock-fs": "^5.2.0",
     "postcss": "^8.4.35",
@@ -52,6 +51,7 @@
     "uuid": "^9.0.1",
     "vite": "^5.0.3",
     "vite-node": "^1.3.1",
+    "chokidar": "^3.5.3",
     "vitest": "^1.2.2"
   },
   "dependencies": {

--- a/apps/server/plugins/configWatcher.ts
+++ b/apps/server/plugins/configWatcher.ts
@@ -1,0 +1,43 @@
+import path from 'path'
+import { type HmrContext } from 'vite'
+import fs from 'fs'
+
+declare module 'vite/types/customEvent' {
+  interface CustomEventMap {
+    'config-update': { [key: string]: unknown }
+  }
+}
+
+export default function watchQueriesPlugin() {
+  const configPath = path.resolve(
+    __dirname,
+    '../static/.latitude/latitude.json',
+  )
+  return {
+    name: 'latitude-json-watcher',
+    enforce: 'post',
+    handleHotUpdate({ file, server }: HmrContext) {
+      if (server.config.mode !== 'development') return
+
+      if (file === configPath) {
+        try {
+          const newConfig = JSON.parse(fs.readFileSync(configPath, 'utf8'))
+          // This update will only be sent to the client, not the server. This means
+          // we need to filter out any config values that are not needed on the client
+          // side for security reasons (even though this is only done in dev mode).
+          const clientConfig = {
+            theme: newConfig.theme,
+            themeMode: newConfig.themeMode,
+          }
+          server.ws.send({
+            type: 'custom',
+            event: 'client-config-update', // Handled in hooks.client.ts
+            data: clientConfig,
+          })
+        } catch (error) {
+          throw new Error(`Failed to read and parse latitude.json\n${error}`)
+        }
+      }
+    },
+  }
+}

--- a/apps/server/src/hooks.client.ts
+++ b/apps/server/src/hooks.client.ts
@@ -1,6 +1,8 @@
 import { computeQueries } from '$lib/stores/queries'
+import { config } from '$lib/stores/config'
 
 if (import.meta.hot) {
+  // plugins/queriesWatcher.ts
   import.meta.hot.on('refetch-queries', (payload) => {
     const { queries } = payload
     computeQueries({
@@ -8,5 +10,10 @@ if (import.meta.hot) {
       force: true,
       skipIfParamsUnchanged: false,
     })
+  })
+
+  // plugins/configWatcher.ts
+  import.meta.hot.on('client-config-update', (payload) => {
+    config.set(payload)
   })
 }

--- a/apps/server/src/lib/constants.ts
+++ b/apps/server/src/lib/constants.ts
@@ -1,0 +1,1 @@
+export const APP_CONFIG_PATH = 'static/.latitude/latitude.json'

--- a/apps/server/src/lib/stores/config.ts
+++ b/apps/server/src/lib/stores/config.ts
@@ -1,0 +1,32 @@
+import { writable } from 'svelte/store'
+
+export type LatitudeClientConfig = {
+  theme?: { [key: string]: unknown }
+  themeMode?: 'light' | 'dark' | 'system'
+}
+
+export type LatitudeServerConfig = {
+  name: string
+  version: string
+} & LatitudeClientConfig
+
+export type LatitudeConfig = LatitudeClientConfig | LatitudeServerConfig
+
+/**
+ * Filter out unnecessary config values for the client
+ */
+export function fliterClientConfig(
+  config: LatitudeConfig,
+): LatitudeClientConfig {
+  return {
+    theme: config.theme,
+    themeMode: config.themeMode,
+  }
+}
+
+// This config store is initialized and updated differently in the server and client
+// - In the server, it is initialized and updated in hooks.server.ts
+// - In the client, it is initialized in +layout.svelte (with the initial value from
+//   the server passed from +layout.server.ts) and updated in hooks.client.ts via
+//   the configWatcher plugin
+export const config = writable<LatitudeConfig>({})

--- a/apps/server/src/routes/+layout.server.ts
+++ b/apps/server/src/routes/+layout.server.ts
@@ -1,6 +1,11 @@
-import loadToken, { type TokenResponse } from '$lib/loadToken'
-import { type Load } from '@sveltejs/kit'
+import loadToken from '$lib/loadToken'
+import type { LayoutServerLoad } from './$types'
+import { get } from 'svelte/store'
+import { config, fliterClientConfig } from '$lib/stores/config'
 
-export const load: Load<object, TokenResponse> = async ({ url }) => {
-  return loadToken({ url })
+export const load: LayoutServerLoad = async ({ url }) => {
+  return {
+    ...(await loadToken({ url })),
+    config: fliterClientConfig(get(config)),
+  }
 }

--- a/apps/server/src/routes/+layout.svelte
+++ b/apps/server/src/routes/+layout.svelte
@@ -8,6 +8,8 @@
   import { init as initQueries } from '$lib/stores/queries'
   import { setUrlParam, useViewParams } from '$lib/stores/viewParams'
   import { initIframeCommunication } from '$lib/iframeEmbedding'
+  import { browser } from '$app/environment'
+  import { config } from '$lib/stores/config'
 
   /**
    * FIXME: https://github.com/latitude-dev/latitude/issues/158
@@ -16,6 +18,7 @@
   export let data
   const validToken = data.valid
   const tokenError = data.errorMessage
+  if (browser) config.set(data.config)
 
   onMount(async () => {
     await initQueries()
@@ -29,7 +32,7 @@
   })
 </script>
 
-<ThemeProvider>
+<ThemeProvider theme={$config?.theme ?? {}} mode={$config?.themeMode}>
   <div>
     {#if validToken}
       <slot />

--- a/apps/server/vite.config.ts
+++ b/apps/server/vite.config.ts
@@ -6,11 +6,13 @@ import { defineConfig } from 'vite'
 import autoImport from '@latitude-data/sveltekit-autoimport'
 import latitudePlugin from './plugins/latitude'
 import watchQueries from './plugins/queriesWatcher'
+import watchLatitudeJson from './plugins/configWatcher'
 
 export default defineConfig({
   plugins: [
     latitudePlugin(),
     watchQueries(),
+    watchLatitudeJson(),
     autoImport({
       module: {
         '@latitude-data/svelte': [

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -206,7 +206,7 @@
     },
     {
       "group": "Customization",
-      "pages": ["views/customization/component-styles"]
+      "pages": ["views/customization/theming", "views/customization/component-styles"]
     },
     {
       "group": "Advanced",

--- a/docs/views/customization/theming.mdx
+++ b/docs/views/customization/theming.mdx
@@ -1,38 +1,13 @@
 ---
 title: 'Theming'
-description: 'Customize the look and feel of specific Latitude components in your views'
+description: 'Personalize the theme of your Latitude Views'
 ---
 
-All Latitude components are designed to be easily customized to match your brand. This guide will walk you through the process of customizing the look and feel of Latitude components.
-
-## Changing theme
-
-When Latitude is added to your app, the `LatitudeProvider` component provides a theme for all components. By default, the theme uses the Latitude color palette, but we have a few predefined themes that you can use.
-
-The available themes are available in the `themes` object, which currently has 4 themes:
-
-- **latitude**
-- **rose**
-- **green**
-- **orange**
-
-To use a theme, you can pass the theme name to the `theme` prop of the `LatitudeProvider` component.
-
-```jsx
-import { LatitudeProvider, themes } from '@latitude/core';
-
-function App() {
-  return (
-    <LatitudeProvider theme={themes["rose"]}>
-      <AppContent />
-    </LatitudeProvider>
-  );
-}
-```
+All Latitude components are designed to be easily customized to match your brand. This guide will walk you through the process of customizing the look and feel of Latitude Views.
 
 ## Creating a custom theme
 
-Themes consist of attribute definitions. You can create your own theme by assembling a new object with your chosen values.
+In your `latitude.json` file, you can define a custom theme by adding a `theme` object with your chosen values.
 Each theme includes a set of attributes specifying CSS colors or values for different elements.
 
 Take a look at the default values for the `latitude` theme:
@@ -57,55 +32,42 @@ Take a look at the default values for the `latitude` theme:
 }
 ```
 
-Create your own theme by building on this structure. Color definitions can be in [any format that CSS supports](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value), such as hex, rgb, hsl, etc. You do not have to redefine every property, only the ones you want to change from the default theme.
+Create your own theme by building on this structure. Color definitions can be in [any format that CSS supports](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value), such as hex, rgb, hsl, etc.
+You do not have to redefine every property, only the ones you want to change from the default theme.
   
-```jsx
-import { LatitudeProvider } from '@latitude/react';
-
-const myTheme = {
-  primary: '#254E70',
-  secondary: '#F2F2F2',
-}
-
-function App() {
-  return (
-    <LatitudeProvider theme={myTheme}>
-      <AppContent />
-    </LatitudeProvider>
-  );
+```json latitude.json
+{
+  "name": "my-latitude-project",
+  "theme": {
+    "primary": "#254E70",
+    "background": "#c1c1c1",
+    "foreground": "#000012",
+  }
 }
 ```
 
 ### Dark mode
 
-You can add a `dark` version of your theme by adding a `dark` object to your theme. This object should have the same properties as the main theme, but with the colors inverted.
-With a dark version defined, you can configure the behaviour of your theme with the `mode` property. By default, the mode is set to `light`, but you can change it to `dark` to force dark mode, or `system` to use the system's preference.
+You can add a `dark` version of your theme by adding a `dark` object to your theme. This object should have the same properties as the main theme, but with the colors inverted. If a property is not defined in the `dark` object, the default value will be used.
 
-```jsx
-import { LatitudeProvider } from '@latitude/react';
+With a dark version defined, you can configure the behaviour of your theme with the `themeMode` property. By default, the theme mode is set to `light`, but you can change it to `dark` to force dark mode, or `system` to use the system's preference.
 
-const myTheme = {
-  primary: '#254E70',
-  secondary: '#F2F2F2',
-  background: '#fff',
-  foreground: '#000',
-
-  dark: {
-    background: '#000',
-    foreground: '#fff',
-  }
-}
-
-function App() {
-  return (
-    <LatitudeProvider theme={myTheme} mode="system">
-      <AppContent />
-    </LatitudeProvider>
-  );
+```json latitude.json
+{
+  "name": "my-latitude-project",
+  "theme": {
+    "primary": "#254E70",
+    "background": "#c1c1c1",
+    "foreground": "#000012",
+    "dark": {
+      "primary": "#254E70",
+      "background": "#000012",
+      "foreground": "#c1c1c1",
+    }
+  },
+  "themeMode": "system"
 }
 ```
-
-Then, you can enable dark mode in you app by setting the `mode` prop of the `LatitudeProvider` component to `dark`.
 
 ### Chart styles
 
@@ -301,24 +263,13 @@ You can find the complete echart properties used in Latitude's default theme bel
 If you want to personalize the styles for your charts, we recommend using [echart's online theme builder](https://echarts.apache.org/en/theme-builder.html) to easily create your own styles.
 To do this, simply select the colors you want to use, click on the "Download" at the top-left corner and copy the "JSON version" object into the `echarts` property in your theme.
 
-```jsx
-import { LatitudeProvider } from '@latitude/react';
-
-const myTheme = {
-  echarts: {
-    color: [ '#52B788', '#95D5B2', '#40916C' ],
-  },
-}
-
-function App() {
-  return (
-    <LatitudeProvider theme={myTheme}>
-      <AppContent />
-    </LatitudeProvider>
-  );
+```json latitude.json
+{
+  "name": "my-latitude-project",
+  "theme": {
+    "echarts": {
+      "color": [ "#52B788", "#95D5B2", "#40916C" ],
+    }
+  }
 }
 ```
-
-## Customizing components
-
-For more advanced customization, we recommend using [Tailwind](https://tailwindcss.com/docs/installation), since all Latitude components are built with Tailwind and accept Tailwind classes as props. However, you can use any styling solution you prefer.

--- a/packages/cli/src/lib/sync/index.ts
+++ b/packages/cli/src/lib/sync/index.ts
@@ -1,4 +1,5 @@
 import syncDotenv from './syncDotenv'
+import syncLatitudeJson from './syncLatitudeJson'
 import syncQueries from './syncQueries'
 import syncStaticFiles from './syncStaticFiles'
 import syncViews from './syncViews'
@@ -10,6 +11,7 @@ export default function sync(
     syncViews({ watch }),
     syncStaticFiles({ watch }),
     syncDotenv({ watch }),
+    syncLatitudeJson({ watch }),
     syncQueries({ watch }),
   ])
 }

--- a/packages/cli/src/lib/sync/syncLatitudeJson/index.test.ts
+++ b/packages/cli/src/lib/sync/syncLatitudeJson/index.test.ts
@@ -1,0 +1,69 @@
+import * as fs from 'fs'
+import config from '$src/config'
+import path from 'path'
+import syncDotenv from '.'
+import syncFiles from '../shared/syncFiles'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import watcher from '../shared/watcher'
+
+vi.mock('fs', () => ({
+  existsSync: vi.fn(),
+}))
+vi.mock('$src/config', () => ({
+  default: { rootDir: '/mocked/path' },
+}))
+vi.mock('../shared/syncFiles', () => ({
+  default: vi.fn(),
+}))
+vi.mock('../shared/watcher', () => ({ default: vi.fn() }))
+
+const APP_FOLDER = '.latitude/app'
+
+describe('syncDotenv', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('starts the watcher', () => {
+    syncDotenv({ watch: true })
+
+    expect(syncFiles).not.toHaveBeenCalled()
+    expect(watcher).toHaveBeenCalledWith(
+      '/mocked/path/latitude.json',
+      expect.any(Function),
+    )
+  })
+
+  it('does nothing if latitude.json file does not exist', () => {
+    // @ts-expect-error mock
+    ;(fs.existsSync as vi.Mock).mockReturnValueOnce(false)
+
+    syncDotenv()
+    expect(fs.existsSync).toHaveBeenCalled()
+    expect(syncFiles).not.toHaveBeenCalled()
+  })
+
+  it('syncs latitude.json file to the app folder if it exists', () => {
+    // @ts-expect-error mock
+    ;(fs.existsSync as vi.Mock).mockReturnValueOnce(true)
+
+    syncDotenv()
+
+    const expectedSrcPath = path.join(config.rootDir, 'latitude.json')
+    const expectedDestPath = path.join(
+      config.rootDir,
+      APP_FOLDER,
+      'static/.latitude',
+      'latitude.json',
+    )
+
+    expect(fs.existsSync).toHaveBeenCalledWith(expectedSrcPath)
+    expect(syncFiles).toHaveBeenCalledWith({
+      srcPath: expectedSrcPath,
+      destPath: expectedDestPath,
+      relativePath: 'latitude.json',
+      type: 'add',
+      ready: true,
+    })
+  })
+})

--- a/packages/cli/src/lib/sync/syncLatitudeJson/index.ts
+++ b/packages/cli/src/lib/sync/syncLatitudeJson/index.ts
@@ -1,0 +1,56 @@
+import config from '$src/config'
+import path from 'path'
+import syncFiles from '../shared/syncFiles'
+import { APP_FOLDER } from '$src/commands/constants'
+import { existsSync, rmSync } from 'fs'
+import watcher from '../shared/watcher'
+import { onExit } from '$src/utils'
+
+const filename = 'latitude.json'
+
+export default async function syncLatitudeJson(
+  {
+    watch = false,
+  }: {
+    watch?: boolean
+  } = { watch: false },
+) {
+  const destPath = path.join(
+    config.rootDir,
+    APP_FOLDER,
+    'static/.latitude',
+    filename,
+  )
+  const srcPath = path.join(config.rootDir, filename)
+
+  if (watch) {
+    await watcher(
+      srcPath,
+      (srcPath: string, type: 'add' | 'change' | 'unlink', ready: boolean) => {
+        syncFiles({
+          srcPath,
+          destPath,
+          type,
+          ready,
+          relativePath: filename,
+        })
+      },
+    )
+  } else {
+    if (!existsSync(srcPath)) return
+
+    syncFiles({
+      srcPath,
+      destPath,
+      relativePath: filename,
+      type: 'add',
+      ready: true,
+    })
+  }
+
+  onExit(() => {
+    if (!watch) return
+
+    if (existsSync(destPath)) rmSync(destPath)
+  })
+}

--- a/packages/cli/src/lib/v1.schema.json
+++ b/packages/cli/src/lib/v1.schema.json
@@ -9,8 +9,17 @@
       "type": "string",
       "minLength": 5,
       "maxLength": 14,
-      "pattern": "^(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)$",
+      "pattern": "^(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)(?:-next\\.(?:0|[1-9]\\d*))?$",
       "description": "Latitude app version used."
+    },
+    "theme": {
+      "type": "object",
+      "description": "Theme configuration."
+    },
+    "themeMode": {
+      "type": "string",
+      "enum": ["light", "dark", "system"],
+      "description": "Theme mode for the app. 'system' will follow the system theme."
     }
   },
   "required": ["version"],

--- a/packages/client/core/src/theme/skins/buildCssVariables.test.ts
+++ b/packages/client/core/src/theme/skins/buildCssVariables.test.ts
@@ -43,7 +43,7 @@ describe('build css variables', () => {
         --lat-ring: ${light.ring};
         --lat-radius: ${light.radius};
       }
-      .dark {
+      .lat-dark {
         --lat-card: ${dark.card};
         --lat-card-foreground: ${dark['card-foreground']};
         --lat-popover: ${dark.popover};

--- a/packages/client/core/src/theme/skins/buildCssVariables.ts
+++ b/packages/client/core/src/theme/skins/buildCssVariables.ts
@@ -18,7 +18,7 @@ export function buildCssVariables(theme: Theme): string {
   return `:root {
 ${mapThemeToCssVariables(light)}
 }
-.dark {
+.lat-dark {
 ${mapThemeToCssVariables(dark)}
 }`
 }

--- a/packages/client/react/package.json
+++ b/packages/client/react/package.json
@@ -41,7 +41,8 @@
     "npm": "^10.5.2",
     "react-table": "^7.8.0",
     "tailwind-merge": "^2.2.1",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "use-prefers-color-scheme": "^1.1.3"
   },
   "peerDependencies": {
     "react": ">=16.8.0",

--- a/packages/client/react/src/MainProvider.tsx
+++ b/packages/client/react/src/MainProvider.tsx
@@ -9,12 +9,13 @@ type LatitudeProviderProps = QueryClientProviderProps &
 function LatitudeProvider({
   children,
   theme,
+  mode,
   ...props
 }: LatitudeProviderProps) {
   return (
     <LatitudeApiProvider {...props}>
       {theme !== false ? (
-        <LatitudeThemeProvider theme={theme} {...props}>
+        <LatitudeThemeProvider theme={theme} mode={mode}>
           {children}
         </LatitudeThemeProvider>
       ) : (

--- a/packages/client/react/src/lib/internal/shared/Echart.tsx
+++ b/packages/client/react/src/lib/internal/shared/Echart.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 import { debounce } from 'lodash-es'
 import * as echarts from 'echarts/core'
 import { CanvasRenderer } from 'echarts/renderers'
@@ -58,24 +58,24 @@ export default function Echart({
 }: Props) {
   const chartRef = useRef<HTMLDivElement | null>(null)
   const chartInstance = useRef<echarts.ECharts | null>(null)
-  const { currentTheme } = useLatitudeTheme()
+  const { theme, mode } = useLatitudeTheme()
+
+  const echartsTheme = useMemo(() => {
+    return mode === 'dark' ? theme.dark.echarts : theme.echarts
+  }, [theme, mode])
 
   // Initialize the chart
   useEffect(() => {
     if (!chartRef.current) return
-    chartInstance.current = echarts.init(
-      chartRef.current,
-      currentTheme.echarts,
-      {
-        renderer: 'canvas',
-        locale,
-      },
-    )
+    chartInstance.current = echarts.init(chartRef.current, echartsTheme, {
+      renderer: 'canvas',
+      locale,
+    })
 
     return () => {
       chartInstance.current?.dispose()
     }
-  }, [currentTheme, locale])
+  }, [echartsTheme, locale])
 
   useEffect(() => {
     chartInstance.current?.resize()

--- a/packages/client/react/src/lib/theme/useTheme.ts
+++ b/packages/client/react/src/lib/theme/useTheme.ts
@@ -6,10 +6,12 @@ const defaultTheme = client.skins.defaultTheme
 
 type Theme = client.skins.Theme
 type PartialTheme = client.skins.PartialTheme
+type ThemeMode = 'light' | 'dark'
 
 const ThemeContext = createContext({
-  currentTheme: defaultTheme as Theme,
-  setCurrentTheme: (_: Theme) => {},
+  theme: defaultTheme as Theme,
+  setTheme: (_: Theme) => {},
+  mode: 'light' as ThemeMode,
 })
 
 const useLatitudeTheme = () => useContext(ThemeContext)

--- a/packages/client/svelte/src/lib/ui/theme-provider/index.svelte
+++ b/packages/client/svelte/src/lib/ui/theme-provider/index.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { setContext } from 'svelte'
   import { theme as client } from '@latitude-data/client'
-  import { ModeWatcher, mode } from 'mode-watcher'
+  import { ModeWatcher, mode, setMode } from 'mode-watcher'
   import { derived, writable } from 'svelte/store'
 
   const buildCss = client.skins.buildCssVariables
@@ -9,6 +9,7 @@
 
   type $$Props = {
     theme?: client.skins.PartialTheme
+    mode?: 'light' | 'dark' | 'system'
   }
 
   const LATITUDE_STYLE_ID = 'latitude-variables'
@@ -16,6 +17,10 @@
 
   let partialTheme: $$Props['theme'] = client.skins.defaultTheme
   export { partialTheme as theme }
+
+  let initialMode: $$Props['mode'] = 'light'
+  export { initialMode as mode }
+  $: setMode(initialMode || 'light')
 
   const theme = writable<client.skins.Theme>(partialTheme ? createTheme(partialTheme) : client.skins.defaultTheme)
   $: if (partialTheme) theme.set(createTheme(partialTheme))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -528,6 +528,9 @@ importers:
       tailwindcss-animate:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@3.4.3)
+      use-prefers-color-scheme:
+        specifier: ^1.1.3
+        version: 1.1.3(react@18.2.0)
     devDependencies:
       '@latitude-data/eslint-config':
         specifier: workspace:*
@@ -9170,7 +9173,7 @@ packages:
     peerDependencies:
       '@sveltejs/kit': ^2.0.0
     dependencies:
-      '@sveltejs/kit': 2.5.0(@sveltejs/vite-plugin-svelte@3.0.0)(svelte@4.2.10)(vite@5.0.12)
+      '@sveltejs/kit': 2.5.0(@sveltejs/vite-plugin-svelte@3.0.0)(svelte@4.2.7)(vite@5.0.12)
       import-meta-resolve: 4.0.0
     dev: true
 
@@ -23362,6 +23365,15 @@ packages:
       '@types/react': 18.2.74
       react: 18.2.0
       tslib: 2.6.2
+
+  /use-prefers-color-scheme@1.1.3(react@18.2.0):
+    resolution: {integrity: sha512-ZRgDfb5BFLum/Sud4SpZ+d1YcV+lRbsupw0qQ/rGy5kGrpE3KMUQgEQOKiQQSa4Wslex46n5fKFO+9FGMTosUQ==}
+    engines: {node: '>=8', npm: '>=5'}
+    peerDependencies:
+      react: '>= 16.8.0'
+    dependencies:
+      react: 18.2.0
+    dev: false
 
   /use-resize-observer@9.1.0(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-R25VqO9Wb3asSD4eqtcxk8sJalvIOYBqS8MNZlpDSQ4l4xMQxC/J7Id9HoTqPq8FwULIn0PVW+OAqF2dyYbjow==}


### PR DESCRIPTION
## Describe your changes
Added support for custom theming on Latitude Views, by adding a `theme` attribute to the latitude.json file. Also, in dev mode, it has hot-reload features to see the new theme in real time.

https://github.com/latitude-dev/latitude/assets/57395395/158e93e2-15a4-46b6-9ff4-ed7ccf3f9007

- The CLI now syncs the latitude.json file to `static/.latitude/latitude.json`
- The server reads the file and sends the theme values to the client.
- Both the server and client update the theme value in real time when the file is updated.
- Also added support for specifying the color theme in the React package

## Hot-reloading
The hot-reloading works differently on the client and the server.
- **server**: For the server, the theme is initialized in `hooks.server.ts`, where the whole latitude.json file is read. When running in dev mode, this same file initializes a `chokidar` watcher to update the value of the theme each time this file is updated.
- **client**: For the client, the theme is initialized in `+layout.svelte`, where the server sends its current value as a `LayoutServerData` via `+layout.server.ts`. Svelte magic stuff. When running in dev mode, a Vite plugin watches for changes in the latitude.json file, reads the config, and sends the updated theme to the client via websockets, which then updates the value for the client in `hooks.client.ts`

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have added thorough tests
- [x] I have updated the documentation if necessary
- [x] I have added a human-readable description of the changes for the release notes
- [x] I have included a recorded video capture of the feature manually tested

