### PR TITLE
Materialize storage driver package

### DIFF
--- a/.changeset/mighty-taxis-know.md
+++ b/.changeset/mighty-taxis-know.md
@@ -1,0 +1,5 @@
+---
+"@latitude-data/source-manager": minor
+---
+
+Work in progress introduce materialize storage

--- a/apps/server/scripts/run_query/index.ts
+++ b/apps/server/scripts/run_query/index.ts
@@ -1,6 +1,7 @@
 import QueryDisplay from './result_display'
 import chokidar from 'chokidar'
-import sourceManager, { QUERIES_DIR } from '../../src/lib/server/sourceManager'
+import sourceManager from '../../src/lib/server/sourceManager'
+import { QUERIES_DIR } from '../../src/lib/constants'
 
 type CommandArgs = {
   queryPath: string

--- a/apps/server/src/lib/constants.ts
+++ b/apps/server/src/lib/constants.ts
@@ -1,1 +1,4 @@
-export const APP_CONFIG_PATH = 'static/.latitude/latitude.json'
+export const BASE_STATIC_PATH = 'static/.latitude'
+export const APP_CONFIG_PATH = `${BASE_STATIC_PATH}/latitude.json`
+export const QUERIES_DIR = `${BASE_STATIC_PATH}/queries`
+export const MATERIALIZE_DIR = `${BASE_STATIC_PATH}/materialize_queries`

--- a/apps/server/src/lib/query_service/find_or_compute.test.ts
+++ b/apps/server/src/lib/query_service/find_or_compute.test.ts
@@ -2,8 +2,8 @@ import mockFs from 'mock-fs'
 import { vi, it, describe, beforeEach, afterEach, expect } from 'vitest'
 import sourceManager from '$lib/server/sourceManager'
 
-import { QUERIES_DIR } from '$lib/server/sourceManager'
 import findOrCompute from './find_or_compute'
+import { QUERIES_DIR } from '$lib/constants'
 
 async function buildConnector(queryPath: string) {
   const source = await sourceManager.loadFromQuery(queryPath)

--- a/apps/server/src/lib/server/sourceManager.test.ts
+++ b/apps/server/src/lib/server/sourceManager.test.ts
@@ -1,0 +1,81 @@
+import mockFs from 'mock-fs'
+import { vi, describe, it, expect } from 'vitest'
+import {
+  SourceManager,
+  STORAGE_TYPES,
+  type StorageType,
+  buildStorageDriver,
+} from '@latitude-data/source-manager'
+import { BASE_STATIC_PATH, MATERIALIZE_DIR, QUERIES_DIR } from '$lib/constants'
+import { buildSourceManager } from '$lib/server/sourceManager'
+
+vi.mock('@latitude-data/source-manager', async (importOriginal) => {
+  const original = (await importOriginal()) as typeof importOriginal
+  return {
+    ...original,
+    SourceManager: vi.fn(),
+  }
+})
+
+describe('buildSourceManager', () => {
+  it('should return a new SourceManager instance', () => {
+    mockFs({
+      [BASE_STATIC_PATH]: {
+        'latitde.json': `{
+          "materialize": {
+            "storage": {
+              "type": "disk",
+             }
+          }
+        }`,
+        'query.sql': 'SELECT * FROM table',
+      },
+    })
+
+    buildSourceManager()
+    expect(SourceManager).toHaveBeenCalledWith(QUERIES_DIR, {
+      materializeStorage: buildStorageDriver({
+        type: STORAGE_TYPES.disk as StorageType,
+        config: { path: MATERIALIZE_DIR },
+      }),
+    })
+  })
+
+  it('fallbacks to disk driver when weird config', () => {
+    mockFs({
+      [BASE_STATIC_PATH]: {
+        'latitde.json': `{
+          "materialize": {
+            "storage": {
+              "type": "weird",
+             }
+          }
+        }`,
+        'query.sql': 'SELECT * FROM table',
+      },
+    })
+
+    buildSourceManager()
+    expect(SourceManager).toHaveBeenCalledWith(QUERIES_DIR, {
+      materializeStorage: buildStorageDriver({
+        type: STORAGE_TYPES.disk as StorageType,
+        config: { path: MATERIALIZE_DIR },
+      }),
+    })
+  })
+
+  it('fallbacks to disk driver when latitude.json does not exist', () => {
+    mockFs({
+      [BASE_STATIC_PATH]: {
+        'query.sql': 'SELECT * FROM table',
+      },
+    })
+    buildSourceManager()
+    expect(SourceManager).toHaveBeenCalledWith(QUERIES_DIR, {
+      materializeStorage: buildStorageDriver({
+        type: STORAGE_TYPES.disk as StorageType,
+        config: { path: MATERIALIZE_DIR },
+      }),
+    })
+  })
+})

--- a/apps/server/src/lib/server/sourceManager.ts
+++ b/apps/server/src/lib/server/sourceManager.ts
@@ -1,6 +1,46 @@
-import { SourceManager } from '@latitude-data/source-manager'
+import fs from 'fs'
+import { APP_CONFIG_PATH, MATERIALIZE_DIR, QUERIES_DIR } from '$lib/constants'
+import {
+  SourceManager,
+  StorageConfig,
+  STORAGE_TYPES,
+  buildStorageDriver,
+  type StorageType,
+} from '@latitude-data/source-manager'
 
-export const QUERIES_DIR = 'static/.latitude/queries'
-const sourceManager = new SourceManager(QUERIES_DIR)
+const DEFAULT_STORAGE_CONFIG = {
+  type: STORAGE_TYPES.disk as StorageType,
+  config: { path: MATERIALIZE_DIR },
+}
 
+function loadStorageConfig(): StorageConfig<StorageType> {
+  if (!fs.existsSync(APP_CONFIG_PATH)) {
+    return DEFAULT_STORAGE_CONFIG
+  }
+
+  const file = fs.readFileSync(APP_CONFIG_PATH, 'utf8')
+  try {
+    const config = JSON.parse(file)
+    // We set the `path` to the default materialize directory
+    if (config.type == STORAGE_TYPES.disk) return DEFAULT_STORAGE_CONFIG
+
+    return config
+  } catch (e) {
+    return DEFAULT_STORAGE_CONFIG
+  }
+}
+
+/**
+ * When initializing the SourceManager,
+ * we first load the storage config from the latitude.json file.
+ * We configure materialize storage driver based on the config.
+ */
+export function buildSourceManager() {
+  const config = loadStorageConfig()
+  const storageDriver = buildStorageDriver(config)
+  const driver = storageDriver || buildStorageDriver(DEFAULT_STORAGE_CONFIG)
+  return new SourceManager(QUERIES_DIR, { materializeStorage: driver })
+}
+
+const sourceManager = buildSourceManager()
 export default sourceManager

--- a/apps/server/src/routes/api/queries/[...query]/server.test.ts
+++ b/apps/server/src/routes/api/queries/[...query]/server.test.ts
@@ -5,7 +5,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import QueryResult, { DataType } from '@latitude-data/query_result'
 import cache from '$lib/query_service/query_cache'
 import { MISSING_KEY } from '$lib/loadToken'
-import { QUERIES_DIR } from '$lib/server/sourceManager'
+import { QUERIES_DIR } from '$lib/constants'
 import { GET } from './+server'
 
 const PAYLOAD = {
@@ -63,7 +63,7 @@ describe('GET endpoint', async () => {
   it('should return 500 status on query execution error', async () => {
     vi.spyOn(cache, 'find').mockReturnValueOnce(null) // No cached query
     const customErrorMessage = 'Custom error message'
-    fs.writeFileSync(`${QUERIES_DIR}/query.sql`, `FAIL ${customErrorMessage}`) // (TestConnector feature)
+    fs.writeFileSync(`${QUERIES_DIR}/query.sql`, `FAIL ${customErrorMessage}`)
 
     const response = await GET({
       params: { query: 'query' },

--- a/apps/server/src/routes/api/queries/[...query]/specialParams.test.ts
+++ b/apps/server/src/routes/api/queries/[...query]/specialParams.test.ts
@@ -5,7 +5,7 @@ import findOrCompute from '$lib/query_service/find_or_compute'
 import { signJwt } from '@latitude-data/jwt'
 import { GET } from './+server'
 import QueryResult from '@latitude-data/query_result'
-import { QUERIES_DIR } from '$lib/server/sourceManager'
+import { QUERIES_DIR } from '$lib/constants'
 
 const PAYLOAD = { fields: [], rows: [], rowCount: 0 }
 const queryResult = new QueryResult(PAYLOAD)

--- a/packages/connectors/materialized/src/tests/helpers.ts
+++ b/packages/connectors/materialized/src/tests/helpers.ts
@@ -1,12 +1,14 @@
 import MaterializedConnector, { type ConnectionParams } from '$/index'
 import {
   ConnectorType,
+  DiskDriver,
   Source,
   SourceManager,
   type SourceSchema,
 } from '@latitude-data/source-manager'
 
 export const QUERIES_DIR = 'static/.latitude/queries'
+export const MATERIALIZE_QUERIES_DIR = 'static/.latitude/materialize_queries'
 
 export async function buildMaterializedConnector({
   connectionParams,
@@ -19,10 +21,13 @@ export async function buildMaterializedConnector({
     schema?: Omit<SourceSchema, 'type'>
   }
   queriesDir?: string
+  materializedQueriesDir?: string
 }) {
   const connParams = connectionParams ?? {}
   const sourceSchema = sourceParams.schema ?? {}
-  const sourceManager = new SourceManager(queriesDir ?? QUERIES_DIR)
+  const sourceManager = new SourceManager(queriesDir ?? QUERIES_DIR, {
+    materializeStorage: new DiskDriver({ path: MATERIALIZE_QUERIES_DIR }),
+  })
   const source = new Source({
     path: sourceParams.path,
     schema: { type: ConnectorType.Materialized, ...sourceSchema },

--- a/packages/source_manager/rollup.config.mjs
+++ b/packages/source_manager/rollup.config.mjs
@@ -17,6 +17,7 @@ export default {
     'yaml',
     'fs',
     'path',
+    'crypto',
     'dotenv/config',
     '@latitude-data/sql-compiler',
     '@latitude-data/query_result',

--- a/packages/source_manager/src/index.ts
+++ b/packages/source_manager/src/index.ts
@@ -1,5 +1,7 @@
 export * from './types'
 export { default as SourceManager } from './manager'
+export * from './materialize'
+export * from './materialize/drivers'
 export * from './source'
 export * from './baseConnector'
 export { default as TestConnectorInternal } from './testConnector'

--- a/packages/source_manager/src/manager/index.ts
+++ b/packages/source_manager/src/manager/index.ts
@@ -5,13 +5,20 @@ import findSourceConfigFromQuery from './findSourceConfig'
 import { QueryNotFoundError, SourceFileNotFoundError } from '@/types'
 import { Source } from '@/source'
 import readSourceConfig from '@/source/readConfig'
+import { StorageDriver } from '@/materialize/drivers/StorageDriver'
+import DummyDriver from '@/materialize/drivers/dummy/DummyDriver'
 
 export default class SourceManager {
   private instances: Record<string, Source> = {}
+  readonly materializeStorage: StorageDriver
   readonly queriesDir: string
 
-  constructor(queriesDir: string) {
+  constructor(
+    queriesDir: string,
+    options: { materializeStorage?: StorageDriver } = {},
+  ) {
     this.queriesDir = queriesDir
+    this.materializeStorage = options.materializeStorage ?? new DummyDriver()
   }
 
   /**

--- a/packages/source_manager/src/materialize/drivers/StorageDriver.ts
+++ b/packages/source_manager/src/materialize/drivers/StorageDriver.ts
@@ -1,0 +1,29 @@
+import { createHash } from 'crypto'
+
+export type GetUrlParams = { sql: string; queryName: string; queryPath: string }
+export type ResolveUrlParams = GetUrlParams & { filename: string }
+export class MaterializedFileNotFoundError extends Error {}
+
+/**
+ * In order to hash a SQL query, we need to know the source path
+ * it came from. This way we ensure the path is unique even
+ * if two sources share the same query.
+ */
+export abstract class StorageDriver {
+  getUrl(args: GetUrlParams): Promise<string> {
+    const name = this.hashName(args)
+    const filename = `${name}.parquet`
+
+    return this.resolveUrl({ ...args, filename })
+  }
+
+  /**
+   * It's a Promise because other adapters can be async
+   */
+  abstract resolveUrl({ filename }: ResolveUrlParams): Promise<string>
+
+  private hashName({ sql, queryPath }: GetUrlParams) {
+    const hash = createHash('sha256')
+    return hash.update(`${sql}__${queryPath}`).digest('hex')
+  }
+}

--- a/packages/source_manager/src/materialize/drivers/disk/DiskDriver.test.ts
+++ b/packages/source_manager/src/materialize/drivers/disk/DiskDriver.test.ts
@@ -1,0 +1,69 @@
+import mockFs from 'mock-fs'
+import { describe, it, expect, beforeEach } from 'vitest'
+import { buildStorageDriver, STORAGE_TYPES, StorageType } from '@/materialize'
+import { MaterializedFileNotFoundError } from '../StorageDriver'
+
+const BASE_PATH = 'static/.latutude/materialized_queries'
+const POSTGRESQL_QUERY_PARQUET =
+  '9243cff7f8807cf05319802bd203cc89e9234d8c146fe30846341fc96a729c37.parquet'
+const MYSQL_QUERY_PARQUET =
+  'ff3ac72c335f07efcc9b7a6d50fa3d093051c6fe1688e045bfa4fe1a6bf13e0d.parquet'
+const POSTGRESQL_QUERY_METADATA =
+  '9243cff7f8807cf05319802bd203cc89e9234d8c146fe30846341fc96a729c37-metadata.json'
+
+const driver = buildStorageDriver({
+  type: STORAGE_TYPES.disk as StorageType,
+  config: { path: BASE_PATH },
+})!
+
+describe('DiskDriver', () => {
+  beforeEach(() => {
+    mockFs({
+      [BASE_PATH]: {
+        [POSTGRESQL_QUERY_PARQUET]: 'POSTGRESQL PARQUET FILE',
+        [POSTGRESQL_QUERY_METADATA]:
+          '{"materializedAt": "2021-01-01T00:00:00Z}',
+        [MYSQL_QUERY_PARQUET]: 'MYSQL PARQUET FILE',
+      },
+    })
+  })
+  describe('getUrl', () => {
+    it('returns a URL for a given SQL query', async () => {
+      const url = await driver.getUrl({
+        sql: 'SELECT * FROM users',
+        queryPath: 'queries/postgresql',
+        queryName: 'query.sql',
+      })
+      expect(url).toBe(`${BASE_PATH}/${POSTGRESQL_QUERY_PARQUET}`)
+    })
+
+    it('returns different URLs for different query path', async () => {
+      const postgresqlFilename = await driver.getUrl({
+        sql: 'SELECT * FROM users',
+        queryPath: 'queries/postgresql',
+        queryName: 'query.sql',
+      })
+      const mysqlFilename = await driver.getUrl({
+        sql: 'SELECT * FROM users',
+        queryPath: 'queries/mysql',
+        queryName: 'query.sql',
+      })
+
+      expect(postgresqlFilename).not.toBe(mysqlFilename)
+    })
+
+    it('fails when the query is not materialized', async () => {
+      await expect(
+        driver.getUrl({
+          sql: 'SELECT * FROM projects',
+          queryPath: 'queries/postgresql',
+          queryName: "'../missing.sql'",
+        }),
+      ).rejects.toThrowError(
+        new MaterializedFileNotFoundError(
+          "materialize query not found for: '../missing.sql'",
+        ),
+      )
+    })
+  })
+})

--- a/packages/source_manager/src/materialize/drivers/disk/DiskDriver.ts
+++ b/packages/source_manager/src/materialize/drivers/disk/DiskDriver.ts
@@ -1,0 +1,29 @@
+import fs from 'fs'
+import path from 'path'
+
+import {
+  MaterializedFileNotFoundError,
+  ResolveUrlParams,
+  StorageDriver,
+} from '@/materialize/drivers/StorageDriver'
+
+export default class DiskDriver extends StorageDriver {
+  private path: string
+
+  constructor({ path }: { path: string }) {
+    super()
+    this.path = path
+  }
+
+  resolveUrl({ queryName, filename }: ResolveUrlParams): Promise<string> {
+    const filepath = path.join(this.path, filename)
+
+    if (fs.existsSync(filepath)) return Promise.resolve(filepath)
+
+    return Promise.reject(
+      new MaterializedFileNotFoundError(
+        `materialize query not found for: ${queryName}`,
+      ),
+    )
+  }
+}

--- a/packages/source_manager/src/materialize/drivers/dummy/DummyDriver.ts
+++ b/packages/source_manager/src/materialize/drivers/dummy/DummyDriver.ts
@@ -1,0 +1,18 @@
+import {
+  GetUrlParams,
+  ResolveUrlParams,
+  StorageDriver,
+} from '@/materialize/drivers/StorageDriver'
+
+export default class DummyDriver extends StorageDriver {
+  getUrl(args: GetUrlParams): Promise<string> {
+    return this.resolveUrl({
+      ...args,
+      filename: `ENCRYPTED[${args.sql}].parquet`,
+    })
+  }
+
+  resolveUrl({ filename }: ResolveUrlParams): Promise<string> {
+    return Promise.resolve(filename)
+  }
+}

--- a/packages/source_manager/src/materialize/drivers/index.ts
+++ b/packages/source_manager/src/materialize/drivers/index.ts
@@ -1,0 +1,3 @@
+export { default as DiskDriver } from './disk/DiskDriver'
+export { default as DummyDriver } from './dummy/DummyDriver'
+export { StorageDriver } from './StorageDriver'

--- a/packages/source_manager/src/materialize/index.ts
+++ b/packages/source_manager/src/materialize/index.ts
@@ -1,0 +1,29 @@
+import DiskDriver from '@/materialize/drivers/disk/DiskDriver'
+
+export const STORAGE_TYPES = {
+  disk: 'disk',
+}
+
+export type StorageType = keyof typeof STORAGE_TYPES
+
+type DriverConfig<T extends StorageType> = T extends 'disk'
+  ? { path: string }
+  : never
+
+export type StorageConfig<T extends StorageType> = {
+  type: T
+  config: DriverConfig<T>
+}
+
+export function buildStorageDriver<T extends StorageType>({
+  type,
+  config,
+}: StorageConfig<T>) {
+  switch (type) {
+    case STORAGE_TYPES.disk:
+      return new DiskDriver(config)
+    default: {
+      return null
+    }
+  }
+}

--- a/packages/source_manager/src/types.ts
+++ b/packages/source_manager/src/types.ts
@@ -2,6 +2,8 @@ import { QueryResultArray } from '@latitude-data/query_result'
 import { type SupportedMethod } from '@latitude-data/sql-compiler'
 export { CompileError } from '@latitude-data/sql-compiler'
 
+export type { GetUrlParams } from './materialize/drivers/StorageDriver'
+
 export enum ConnectorType {
   Athena = 'athena',
   Clickhouse = 'clickhouse',


### PR DESCRIPTION
## Describe your changes
When reading with DuckDB the parquet files from materialized queries we need a way of knowing where those queries are stored. We want to allow different ways of storing these parquet files. In this commit we start implementing the driver and the disk implementation that will be used almost always in development

## Issue ticket number and link
https://github.com/latitude-dev/latitude/issues/369

## Checklist before requesting a review
- [x] Implement disk driver
- [x] Pass materialize storage to sourceManager in `apps/server`
- [x] Get materialized file from storage in Materialize connector
- [x] Fail when file is not in materialize storage

