### PR TITLE
Easier theme creation

### DIFF
--- a/.changeset/nasty-queens-draw.md
+++ b/.changeset/nasty-queens-draw.md
@@ -1,0 +1,5 @@
+---
+"@latitude-data/client": minor
+---
+
+Creating themes is now easier. Some attributes for the theme will be automatically added. For example, adding `foreground` will also update the `card-foreground`, `popover-foreground` and echart attributes to match it. These can still be modified inpedendently, but now they will be automatically added by default.

--- a/packages/client/core/src/theme/skins/addDefaultAttributes.test.ts
+++ b/packages/client/core/src/theme/skins/addDefaultAttributes.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest'
+import addDefaultAttributes from './addDefaultAttributes'
+import { PartialThemeAttributes } from './types'
+
+describe('addDefaultAttributes', () => {
+  it('should add default attributes when background and foreground are provided', () => {
+    const attrs: PartialThemeAttributes = {
+      background: 'white',
+      foreground: 'black',
+    }
+    const expected: PartialThemeAttributes = {
+      card: 'white',
+      'card-foreground': 'black',
+      popover: 'white',
+      'popover-foreground': 'black',
+      background: 'white',
+      foreground: 'black',
+    }
+    const result = addDefaultAttributes(attrs)
+    expect(result).toEqual(expected)
+  })
+
+  it('should not overwrite existing attributes', () => {
+    const attrs: PartialThemeAttributes = {
+      background: 'white',
+      foreground: 'black',
+      card: 'gray',
+    }
+    const expected: PartialThemeAttributes = {
+      card: 'gray',
+      'card-foreground': 'black',
+      popover: 'white',
+      'popover-foreground': 'black',
+      background: 'white',
+      foreground: 'black',
+    }
+    const result = addDefaultAttributes(attrs)
+    expect(result).toEqual(expected)
+  })
+
+  it('should handle missing background and foreground attributes', () => {
+    const attrs: PartialThemeAttributes = {
+      card: 'gray',
+    }
+    const expected: PartialThemeAttributes = {
+      card: 'gray',
+    }
+    const result = addDefaultAttributes(attrs)
+    expect(result).toEqual(expected)
+  })
+
+  it('should not include undefined attributes', () => {
+    const attrs: PartialThemeAttributes = {
+      background: 'white',
+      foreground: undefined,
+    }
+    const expected: PartialThemeAttributes = {
+      card: 'white',
+      popover: 'white',
+      background: 'white',
+    }
+    const result = addDefaultAttributes(attrs)
+    expect(result).toEqual(expected)
+  })
+
+  it('should handle empty attributes object', () => {
+    const attrs: PartialThemeAttributes = {}
+    const expected: PartialThemeAttributes = {}
+    const result = addDefaultAttributes(attrs)
+    expect(result).toEqual(expected)
+  })
+
+  it('should correctly handle only foreground attribute', () => {
+    const attrs: PartialThemeAttributes = {
+      foreground: 'black',
+    }
+    const expected: PartialThemeAttributes = {
+      'card-foreground': 'black',
+      'popover-foreground': 'black',
+      foreground: 'black',
+    }
+    const result = addDefaultAttributes(attrs)
+    expect(result).toEqual(expected)
+  })
+
+  it('should correctly handle only background attribute', () => {
+    const attrs: PartialThemeAttributes = {
+      background: 'white',
+    }
+    const expected: PartialThemeAttributes = {
+      card: 'white',
+      popover: 'white',
+      background: 'white',
+    }
+    const result = addDefaultAttributes(attrs)
+    expect(result).toEqual(expected)
+  })
+
+  it('should not mutate the input attributes object', () => {
+    const attrs: PartialThemeAttributes = {
+      background: 'white',
+      foreground: 'black',
+    }
+    const attrsClone = { ...attrs }
+
+    addDefaultAttributes(attrs)
+
+    expect(attrs).toEqual(attrsClone)
+  })
+})

--- a/packages/client/core/src/theme/skins/addDefaultAttributes.ts
+++ b/packages/client/core/src/theme/skins/addDefaultAttributes.ts
@@ -1,0 +1,18 @@
+import { PartialThemeAttributes } from './types'
+import { removeUndefined } from './utils'
+
+export default function addDefaultAttributes(
+  attrs: PartialThemeAttributes,
+): PartialThemeAttributes {
+  const filledAttrs = {
+    card: attrs['background'],
+    'card-foreground': attrs['foreground'],
+    popover: attrs['background'],
+    'popover-foreground': attrs['foreground'],
+  }
+
+  return {
+    ...(removeUndefined(filledAttrs) as PartialThemeAttributes),
+    ...attrs,
+  }
+}

--- a/packages/client/core/src/theme/skins/buildCssVariables.test.ts
+++ b/packages/client/core/src/theme/skins/buildCssVariables.test.ts
@@ -22,12 +22,12 @@ describe('build css variables', () => {
 
     expect(cssVariables).toEqual(
       `:root {
-        --lat-background: ${light.background};
-        --lat-foreground: ${light.foreground};
         --lat-card: ${light.card};
         --lat-card-foreground: ${light['card-foreground']};
         --lat-popover: ${light.popover};
         --lat-popover-foreground: ${light['popover-foreground']};
+        --lat-background: ${light.background};
+        --lat-foreground: ${light.foreground};
         --lat-primary: ${light.primary};
         --lat-primary-foreground: ${light['primary-foreground']};
         --lat-secondary: ${light.secondary};
@@ -44,12 +44,12 @@ describe('build css variables', () => {
         --lat-radius: ${light.radius};
       }
       .dark {
-        --lat-background: ${dark.background};
-        --lat-foreground: ${dark.foreground};
         --lat-card: ${dark.card};
         --lat-card-foreground: ${dark['card-foreground']};
         --lat-popover: ${dark.popover};
         --lat-popover-foreground: ${dark['popover-foreground']};
+        --lat-background: ${dark.background};
+        --lat-foreground: ${dark.foreground};
         --lat-primary: ${dark.primary};
         --lat-primary-foreground: ${dark['primary-foreground']};
         --lat-secondary: ${dark.secondary};

--- a/packages/client/core/src/theme/skins/buildEchartsTheme.test.ts
+++ b/packages/client/core/src/theme/skins/buildEchartsTheme.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest'
+import buildEchartsTheme from './buildEchartsTheme'
+import { TailwindAttributes, EchartTheme } from './types'
+
+describe('buildEchartsTheme', () => {
+  it('should build an Echarts theme with all attributes provided', () => {
+    const attrs: Partial<TailwindAttributes> = {
+      background: 'background',
+      foreground: 'foreground',
+      'muted-foreground': 'muted_foreground',
+      'primary-foreground': 'primary_foreground',
+      border: 'border',
+      primary: 'primary',
+      destructive: 'destructive',
+      muted: 'muted',
+      'secondary-foreground': 'secondary_foreground',
+    }
+
+    const expected: Partial<EchartTheme> = {
+      backgroundColor: 'background',
+      titleColor: 'foreground',
+      subtitleColor: 'muted_foreground',
+      textColor: 'foreground',
+      markTextColor: 'primary_foreground',
+      borderColor: 'border',
+      legendTextColor: 'muted_foreground',
+      kColor: 'primary',
+      kBorderColor: 'primary',
+      kBorderColor0: 'destructive',
+      graphLineColor: 'border',
+      mapLabelColor: 'foreground',
+      mapLabelColorE: 'primary',
+      mapBorderColor: 'muted',
+      mapBorderColorE: 'primary',
+      mapAreaColor: 'muted',
+      mapAreaColorE: 'primary_foreground',
+      toolboxColor: 'muted_foreground',
+      toolboxEmphasisColor: 'foreground',
+      tooltipAxisColor: 'border',
+      timelineLineColor: 'secondary_foreground',
+      timelineItemColor: 'muted_foreground',
+      timelineItemColorE: 'muted_foreground',
+      timelineCheckColor: 'background',
+      timelineCheckBorderColor: 'primary',
+      timelineControlColor: 'secondary_foreground',
+      timelineControlBorderColor: 'secondary_foreground',
+      timelineLabelColor: 'secondary_foreground',
+      datazoomBackgroundColor: 'background',
+      datazoomDataColor: 'border',
+      datazoomFillColor: 'muted',
+      datazoomHandleColor: 'border',
+      datazoomLabelColor: 'muted_foreground',
+    }
+
+    const result = buildEchartsTheme(attrs)
+    expect(result).toEqual(expected)
+  })
+
+  it('should omit attributes that are undefined', () => {
+    const attrs: Partial<TailwindAttributes> = {
+      background: 'background',
+      foreground: undefined,
+      'primary-foreground': 'primary_foreground',
+    }
+
+    const expected: Partial<EchartTheme> = {
+      backgroundColor: 'background',
+      datazoomBackgroundColor: 'background',
+      markTextColor: 'primary_foreground',
+      mapAreaColorE: 'primary_foreground',
+      timelineCheckColor: 'background',
+    }
+
+    const result = buildEchartsTheme(attrs)
+    expect(result).toEqual(expected)
+  })
+
+  it('should handle an empty attributes object', () => {
+    const attrs: Partial<TailwindAttributes> = {}
+
+    const expected: Partial<EchartTheme> = {}
+
+    const result = buildEchartsTheme(attrs)
+    expect(result).toEqual(expected)
+  })
+
+  it('should handle attributes with only a few defined values', () => {
+    const attrs: Partial<TailwindAttributes> = {
+      foreground: 'foreground',
+      border: 'border',
+    }
+
+    const expected: Partial<EchartTheme> = {
+      titleColor: 'foreground',
+      textColor: 'foreground',
+      borderColor: 'border',
+      graphLineColor: 'border',
+      mapLabelColor: 'foreground',
+      toolboxEmphasisColor: 'foreground',
+      tooltipAxisColor: 'border',
+      datazoomDataColor: 'border',
+      datazoomHandleColor: 'border',
+    }
+
+    const result = buildEchartsTheme(attrs)
+    expect(result).toEqual(expected)
+  })
+
+  it('should not mutate the input attributes object', () => {
+    const attrs: Partial<TailwindAttributes> = {
+      background: 'background',
+      foreground: 'foreground',
+    }
+
+    const attrsClone = { ...attrs }
+
+    buildEchartsTheme(attrs)
+
+    expect(attrs).toEqual(attrsClone)
+  })
+})

--- a/packages/client/core/src/theme/skins/buildEchartsTheme.ts
+++ b/packages/client/core/src/theme/skins/buildEchartsTheme.ts
@@ -1,0 +1,45 @@
+import { EchartTheme, TailwindAttributes } from './types'
+import { removeUndefined } from './utils'
+
+export default function buildEchartsTheme(
+  attrs: Partial<TailwindAttributes>,
+): Partial<EchartTheme> {
+  // Echarts theme attributes are by default sourced from the regular Latitude theme attributes
+  const echartsTheme = {
+    backgroundColor: attrs['background'],
+    titleColor: attrs['foreground'],
+    subtitleColor: attrs['muted-foreground'],
+    textColor: attrs['foreground'],
+    markTextColor: attrs['primary-foreground'],
+    borderColor: attrs['border'],
+    legendTextColor: attrs['muted-foreground'],
+    kColor: attrs['primary'],
+    kBorderColor: attrs['primary'],
+    kBorderColor0: attrs['destructive'],
+    graphLineColor: attrs['border'],
+    mapLabelColor: attrs['foreground'],
+    mapLabelColorE: attrs['primary'],
+    mapBorderColor: attrs['muted'],
+    mapBorderColorE: attrs['primary'],
+    mapAreaColor: attrs['muted'],
+    mapAreaColorE: attrs['primary-foreground'],
+    toolboxColor: attrs['muted-foreground'],
+    toolboxEmphasisColor: attrs['foreground'],
+    tooltipAxisColor: attrs['border'],
+    timelineLineColor: attrs['secondary-foreground'],
+    timelineItemColor: attrs['muted-foreground'],
+    timelineItemColorE: attrs['muted-foreground'],
+    timelineCheckColor: attrs['background'],
+    timelineCheckBorderColor: attrs['primary'],
+    timelineControlColor: attrs['secondary-foreground'],
+    timelineControlBorderColor: attrs['secondary-foreground'],
+    timelineLabelColor: attrs['secondary-foreground'],
+    datazoomBackgroundColor: attrs['background'],
+    datazoomDataColor: attrs['border'],
+    datazoomFillColor: attrs['muted'],
+    datazoomHandleColor: attrs['border'],
+    datazoomLabelColor: attrs['muted-foreground'],
+  }
+
+  return removeUndefined(echartsTheme) as Partial<EchartTheme>
+}

--- a/packages/client/core/src/theme/skins/index.ts
+++ b/packages/client/core/src/theme/skins/index.ts
@@ -6,43 +6,38 @@ import green from './tones/green'
 // Default Latitude Skin
 import latitude from './tones/latitude'
 import type { PartialTheme, Theme } from './types'
+import { defaultsDeep } from './utils'
+import buildEchartsTheme from './buildEchartsTheme'
+import addDefaultAttributes from './addDefaultAttributes'
 
 /**
- * Recursively merges the partial object with the default object.
- * The default object is used as a fallback for missing attributes in the partial object.
+ * Uses attributes defined in the light theme to complete missing attributes the dark version.
+ * Additionally, it builds some of the Echart theme based on the regular theme attributes.
  */
-export function defaultsDeep<T extends Record<string, unknown>>(
-  partialObject: Partial<T>,
-  defaultObject: T,
-): T {
-  return Object.keys(defaultObject).reduce((acc, key) => {
-    const value =
-      typeof defaultObject[key] === 'object' &&
-      !Array.isArray(defaultObject[key])
-        ? defaultsDeep(
-            partialObject[key] || {},
-            defaultObject[key] as Record<string, unknown>,
-          )
-        : partialObject[key] ?? defaultObject[key]
-    return { ...acc, [key]: value }
-  }, {} as T)
+function completeTheme(partialTheme: PartialTheme): PartialTheme {
+  const { dark: partialDark = {}, ...partialLight } = partialTheme
+  const light = addDefaultAttributes(partialLight)
+  const dark = defaultsDeep(addDefaultAttributes(partialDark), light)
+
+  const lightEcharts = defaultsDeep(
+    light.echarts || {},
+    buildEchartsTheme(light),
+  )
+  const darkEcharts = defaultsDeep(dark.echarts || {}, buildEchartsTheme(dark))
+
+  return {
+    ...light,
+    echarts: lightEcharts,
+    dark: { ...dark, echarts: darkEcharts },
+  }
 }
 
-/**
- * Fills the "dark" attributes with default values from the "light" attributes if not provided.
- */
-function completeDarkAttributes(partialTheme: PartialTheme): PartialTheme {
-  const { dark: partialDark, ...light } = partialTheme
-  const dark = defaultsDeep(partialDark || {}, light)
-  return { ...light, dark }
-}
-
-export const defaultTheme: Theme = completeDarkAttributes(latitude) as Theme
+export const defaultTheme: Theme = completeTheme(latitude) as Theme
 
 export function createTheme(partialTheme: PartialTheme): Theme {
   // First, we add the missing dark attributes to avoid replacing them with default values
   // if they were defined in the custom light theme.
-  partialTheme = completeDarkAttributes(partialTheme)
+  partialTheme = completeTheme(partialTheme)
 
   // Now, add any missing attributes from the default theme.
   return defaultsDeep(partialTheme as Partial<Theme>, defaultTheme)

--- a/packages/client/core/src/theme/skins/types.ts
+++ b/packages/client/core/src/theme/skins/types.ts
@@ -31,7 +31,7 @@ export type Theme = ThemeAttributes & {
   dark: ThemeAttributes
 }
 
-type PartialThemeAttributes = Partial<TailwindAttributes> & {
+export type PartialThemeAttributes = Partial<TailwindAttributes> & {
   echarts?: Partial<EchartTheme>
 }
 

--- a/packages/client/core/src/theme/skins/utils.test.ts
+++ b/packages/client/core/src/theme/skins/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { defaultsDeep } from '.'
+import { defaultsDeep, removeUndefined } from './utils'
 
 describe('defaultsDeep', () => {
   it('merges a partial object with the default object', () => {
@@ -70,12 +70,48 @@ describe('defaultsDeep', () => {
     })
   })
 
-  it('does not add new attributes not present in the default object', () => {
+  it('adds new attributes not present in the default object', () => {
     const defaultObject = { a: 'def_a' }
     const partialObject = { b: 'new_b' } as Partial<typeof defaultObject>
     const result = defaultsDeep(partialObject, defaultObject)
     expect(result).toEqual({
       a: 'def_a',
+      b: 'new_b',
+    })
+  })
+})
+
+describe('removeUndefined', () => {
+  it('removes undefined values from the object', () => {
+    const obj = { a: 'a', b: undefined, c: 'c' }
+    const result = removeUndefined(obj)
+    expect(result).toEqual({
+      a: 'a',
+      c: 'c',
+    })
+  })
+
+  it('does not remove falsey or null values', () => {
+    const obj = { a: undefined, b: null, c: '', d: 0, e: false, f: NaN }
+    const result = removeUndefined(obj)
+    expect(result).toEqual({
+      b: null,
+      c: '',
+      d: 0,
+      e: false,
+      f: NaN,
+    })
+  })
+
+  it('does not remove undefined values from nested objects', () => {
+    const obj = { a: 'a', b: { c: undefined, d: 'd' } }
+    const result = removeUndefined(obj)
+    expect(result).toEqual({
+      a: 'a',
+      b: {
+        c: undefined,
+        d: 'd',
+      },
     })
   })
 })

--- a/packages/client/core/src/theme/skins/utils.ts
+++ b/packages/client/core/src/theme/skins/utils.ts
@@ -1,0 +1,41 @@
+/**
+ * Recursively merges the partial object with the default object.
+ * The default object is used as a fallback for missing attributes in the partial object.
+ */
+export function defaultsDeep<T extends Record<string, unknown>>(
+  partialObject: Partial<T>,
+  defaultObject: T,
+): T {
+  return Object.keys({ ...partialObject, ...defaultObject }).reduce(
+    (acc, key) => {
+      const defaultValue = defaultObject[key]
+      const partialValue = partialObject[key]
+
+      // Get the value from the partial object if exists, otherwise use the default value
+      let value = partialValue ?? defaultValue
+
+      // If the default value is an object, we need to merge it recursively instead
+      const isObject =
+        typeof defaultValue === 'object' && !Array.isArray(defaultValue)
+      if (isObject) {
+        value = defaultsDeep(
+          partialObject[key] || {},
+          defaultObject[key] as Record<string, unknown>,
+        )
+      }
+
+      return { ...acc, [key]: value }
+    },
+    {} as T,
+  )
+}
+
+/**
+ * Removes undefined values from the object.
+ */
+export function removeUndefined<T extends Record<string, unknown>>(obj: T): T {
+  return Object.entries(obj).reduce((acc, [key, value]) => {
+    if (value === undefined) return acc
+    return { ...acc, [key]: value }
+  }, {} as T)
+}


### PR DESCRIPTION
## Describe your changes

Defining a simple theme sometimes can get annoying.

If the user just wants to change the background color from white to gray, they have not only to change `background`, but to change `card` too (every chart uses a card, and since it's the same color as the background by default it is not obvious that it needs to change), and `echarts.backgroundColor` (otherwise the chart background would still be white). Like this:

```json latitude.json
"theme": {
  "background": "#CCC",
  "card": "#CCC",
  "echarts": {
    "backgroundColor": "#CCC"
  }
}
```
👆 This was just to change the background color... It gets worse with `foreground`.

To fix this, now some attributes inherit the value from other attributes. This means that, if the user only defines the `background` color, `card` and `echarts.backgroundColor` will get this value too. These other values can still be defined by the user independently and they will not be overriden.

```json latitude.json
"theme": {
  "background": "#CCC"
}
```

## Checklist before requesting a review
- [x] I have added thorough tests
- [ ] I have updated the documentation if necessary
- [x] I have added a human-readable description of the changes for the release notes
- [x] I have included a recorded video capture of the feature manually tested

