### PR TITLE
fix: undefined passed to query computations

### DIFF
--- a/.changeset/shiny-llamas-teach.md
+++ b/.changeset/shiny-llamas-teach.md
@@ -1,0 +1,5 @@
+---
+"@latitude-data/server": patch
+---
+
+Fix: undefined parameters were getting passed to query compute requests

--- a/apps/server/src/lib/autoimports/forms/Select/index.svelte
+++ b/apps/server/src/lib/autoimports/forms/Select/index.svelte
@@ -83,7 +83,6 @@
 
   $: valuesKey = findValuesKey()
   $: labelsKey = findLabelsKey()
-
   $: userDefinedItems =
     options?.map((item) => {
       if (item && typeof item === 'object' && 'value' in item) {


### PR DESCRIPTION
## Describe your changes

computeQueryParameters was returning view parameters with undefined values which is not the desirable behaviour.

https://github.com/latitude-dev/latitude/assets/1948929/49422234-8d9a-425b-9758-87551b498dd6


## Checklist before requesting a review
- [x] I have added thorough tests
- [x] I have updated the documentation if necessary
- [x] I have added a human-readable description of the changes for the release notes
- [x] I have included a recorded video capture of the feature manually tested

