### PR TITLE
fix: catch mkdir sync errors in cli syncs

### DIFF
--- a/.changeset/itchy-goats-greet.md
+++ b/.changeset/itchy-goats-greet.md
@@ -1,0 +1,5 @@
+---
+"@latitude-data/cli": patch
+---
+
+minor: handle mkdir sync errors and inform the user gracefully

--- a/packages/cli/src/lib/sync/shared/syncFiles.test.ts
+++ b/packages/cli/src/lib/sync/shared/syncFiles.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import syncFiles from './syncFiles' // Adjust the import path accordingly
+import * as fs from 'fs'
+import colors from 'picocolors'
+import output from '$src/lib/output'
+
+// Mocking necessary modules
+vi.mock('fs')
+vi.mock('path')
+vi.mock('$src/lib/output', () => ({
+  default: vi.fn(),
+}))
+vi.mock('picocolors', () => ({
+  default: {
+    red: vi.fn((msg) => msg), // Minimal mocking for readability
+  },
+}))
+
+describe('syncFiles', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('successfully adds a file', async () => {
+    // Assuming the function isn't inherently async; adjust if necessary.
+    syncFiles({
+      srcPath: '/path/to/source/file.txt',
+      relativePath: 'file.txt',
+      destPath: '/path/to/dest/file.txt',
+      type: 'add',
+      ready: true,
+    })
+
+    expect(fs.copyFileSync).toHaveBeenCalledWith(
+      '/path/to/source/file.txt',
+      '/path/to/dest/file.txt',
+    )
+    expect(fs.mkdirSync).toHaveBeenCalledTimes(1)
+    expect(output).not.toHaveBeenCalled()
+  })
+
+  it('handles error when adding a file and directory cannot be created', () => {
+    const error = new Error('Mock directory creation error')
+    vi.spyOn(fs, 'mkdirSync').mockImplementation(() => {
+      throw error
+    })
+    syncFiles({
+      srcPath: '/path/to/source/file.txt',
+      relativePath: 'file.txt',
+      destPath: '/path/to/dest/file.txt',
+      type: 'add',
+      ready: true,
+    })
+
+    expect(output).toHaveBeenCalledWith(
+      colors.red(`/path/to/dest could not be created: ${error.message}`),
+      true,
+    )
+  })
+
+  it('successfully changes a file', () => {
+    syncFiles({
+      srcPath: '/path/to/source/modified-file.txt',
+      relativePath: 'modified-file.txt',
+      destPath: '/path/to/dest/modified-file.txt',
+      type: 'change',
+      ready: true,
+    })
+
+    expect(fs.copyFileSync).toHaveBeenCalledWith(
+      '/path/to/source/modified-file.txt',
+      '/path/to/dest/modified-file.txt',
+    )
+    expect(fs.mkdirSync).toHaveBeenCalledTimes(1)
+    expect(output).not.toHaveBeenCalled()
+  })
+
+  it('handles error when changing a file and file cannot be copied', () => {
+    const error = new Error('Mock copy error')
+    vi.spyOn(fs, 'copyFileSync').mockImplementation(() => {
+      throw error
+    })
+
+    syncFiles({
+      srcPath: '/path/to/source/modified-file.txt',
+      relativePath: 'modified-file.txt',
+      destPath: '/path/to/dest/modified-file.txt',
+      type: 'change',
+      ready: true,
+    })
+
+    expect(fs.copyFileSync).toHaveBeenCalledWith(
+      '/path/to/source/modified-file.txt',
+      '/path/to/dest/modified-file.txt',
+    )
+    expect(output).toHaveBeenCalledWith(
+      colors.red(
+        `modified-file.txt could not be symlinked to /path/to/dest/modified-file.txt: ${error}`,
+      ),
+      true,
+    )
+  })
+  it('successfully unlinks (deletes) a file', () => {
+    syncFiles({
+      srcPath: '', // srcPath is irrelevant in the unlink operation
+      relativePath: 'file-to-delete.txt',
+      destPath: '/path/to/dest/file-to-delete.txt',
+      type: 'unlink',
+      ready: true,
+    })
+
+    expect(fs.unlink).toHaveBeenCalledWith(
+      '/path/to/dest/file-to-delete.txt',
+      expect.any(Function),
+    )
+  })
+
+  it('handles error when unlinking a file fails', () => {
+    const error = new Error('Mock unlink error')
+    vi.spyOn(fs, 'unlink').mockImplementation((_, callback) => {
+      callback(error)
+    })
+
+    syncFiles({
+      srcPath: '', // srcPath is irrelevant for unlink
+      relativePath: 'file-to-delete.txt',
+      destPath: '/path/to/dest/file-to-delete.txt',
+      type: 'unlink',
+      ready: true,
+    })
+
+    expect(fs.unlink).toHaveBeenCalledWith(
+      '/path/to/dest/file-to-delete.txt',
+      expect.any(Function),
+    )
+    expect(output).toHaveBeenCalledWith(
+      colors.red(
+        `/path/to/dest/file-to-delete.txt could not be deleted: ${error}`,
+      ),
+      true,
+    )
+  })
+})

--- a/packages/cli/src/lib/sync/shared/syncFiles.ts
+++ b/packages/cli/src/lib/sync/shared/syncFiles.ts
@@ -17,8 +17,19 @@ export default function syncFiles({
   ready: boolean
 }) {
   if (type === 'add' || type === 'change') {
-    // Make sure all directories in the path exist
-    mkdirSync(path.dirname(destPath), { recursive: true })
+    try {
+      // Make sure all directories in the path exist
+      mkdirSync(path.dirname(destPath), { recursive: true })
+    } catch (err) {
+      return output(
+        colors.red(
+          `${path.dirname(destPath)} could not be created: ${
+            (err as Error).message
+          }`,
+        ),
+        ready,
+      )
+    }
 
     try {
       copyFileSync(srcPath, destPath)


### PR DESCRIPTION
## Describe your changes

We've detected this error several times so it's better we handle it gracefully and inform the user.

fixes LATITUDE-DATA-CLI-10

## Checklist before requesting a review
- [x] I have added thorough tests
- [x] I have updated the documentation if necessary
- [x] I have added a human-readable description of the changes for the release notes
- [x] I have included a recorded video capture of the feature manually tested (noop)

