### PR TITLE
Feature: Multiple select support for Select component

### DIFF
--- a/.changeset/fresh-squids-yell.md
+++ b/.changeset/fresh-squids-yell.md
@@ -1,0 +1,6 @@
+---
+"@latitude-data/svelte": minor
+"@latitude-data/server": minor
+---
+
+New 'multiple' option on Select component to allow selecting multiple items

--- a/.changeset/thick-singers-cover.md
+++ b/.changeset/thick-singers-cover.md
@@ -1,0 +1,6 @@
+---
+"@latitude-data/custom_types": minor
+"@latitude-data/client": minor
+---
+
+added support for arrays

--- a/apps/server/src/lib/autoimports/forms/Select/index.svelte
+++ b/apps/server/src/lib/autoimports/forms/Select/index.svelte
@@ -16,6 +16,7 @@
   type $$Props = {
     param: string
     value?: unknown // Default selected value for the input
+    multiple?: boolean // Allow multiple selections
     placeholder?: string
     label?: string
     description?: string
@@ -32,6 +33,7 @@
 
   export let param: $$Props['param']
   export let value: $$Props['value'] = undefined
+  export let multiple: $$Props['multiple'] = false
   export let placeholder: $$Props['placeholder'] = undefined
   export let label: $$Props['label'] = undefined
   export let description: $$Props['description'] = undefined
@@ -116,6 +118,7 @@
   <Combobox
     items={allItems}
     value={$inputStore}
+    {multiple}
     {onSelect}
     searchBox={Boolean(searchable)}
     {label}

--- a/apps/server/src/lib/stores/viewParams.ts
+++ b/apps/server/src/lib/stores/viewParams.ts
@@ -1,7 +1,7 @@
 import { writable, get, Writable, Readable, derived } from 'svelte/store'
 import { browser } from '$app/environment'
 import { replaceState } from '$app/navigation'
-import { parse } from '@latitude-data/custom_types'
+import { parseFromUrl } from '@latitude-data/custom_types'
 import { LatitudeApi } from '@latitude-data/client'
 
 export type ViewParams = {
@@ -11,12 +11,8 @@ export type ViewParams = {
 const getParamsFromUrl = () => {
   if (!browser) return {}
 
-  const urlParams = new URLSearchParams(globalThis?.location?.search)
-  const newParams: ViewParams = {}
-  urlParams.forEach((value, key) => {
-    newParams[key] = parse(value)
-  })
-  return newParams
+  const url = new URL(globalThis?.location?.href)
+  return parseFromUrl(url.search)
 }
 
 export function setUrlParam(newParams: ViewParams) {

--- a/apps/server/src/routes/api/queries/[...query]/castValue.ts
+++ b/apps/server/src/routes/api/queries/[...query]/castValue.ts
@@ -1,18 +1,18 @@
-import { RichDate, parse } from '@latitude-data/custom_types'
+import { RichDate } from '@latitude-data/custom_types'
 
-export type IValue = string | number | boolean | Date | null
+export type IValue = string | number | boolean | Date | null | Array<IValue>
 
-export default function castValue(value: string): IValue {
+export default function castValue(value: unknown): IValue {
   // TODO: Make this function an actual service with proper testing
-  const parsedValue = parse(value)
-  if (typeof parsedValue !== 'string') {
-    if (parsedValue instanceof RichDate) return parsedValue.resolve()
-    return parsedValue as IValue
+  if (value === 'true') return true
+  if (value === 'false') return false
+
+  if (value instanceof RichDate) return value.resolve()
+  if (!isNaN(Number(value))) return Number(value)
+
+  if (Array.isArray(value)) {
+    return value.map(castValue)
   }
 
-  if (parsedValue === 'true') return true
-  if (parsedValue === 'false') return false
-  if (!isNaN(Number(parsedValue))) return Number(parsedValue)
-
-  return parsedValue
+  return value as IValue
 }

--- a/apps/server/src/routes/api/queries/[...query]/getQueryParams.ts
+++ b/apps/server/src/routes/api/queries/[...query]/getQueryParams.ts
@@ -5,29 +5,26 @@ import {
 } from '@latitude-data/client'
 import castValue, { IValue } from './castValue'
 import getEncryptedParams from './getEncryptedParams'
+import { parseFromUrl } from '@latitude-data/custom_types'
 
 export default async function getQueryParams(url: URL) {
-  const searchParams = url.searchParams
-  let params: { [key: string]: IValue } = {}
-
-  for (const [key, value] of searchParams) {
-    if (PRIVATE_PARAMS.has(key)) continue
-
-    params[key] = castValue(value)
-  }
-
   const privateParams: { [key: string]: IValue } = {}
-  for (const key of PRIVATE_PARAMS) {
-    if (searchParams.has(key)) {
-      privateParams[key] = castValue(searchParams.get(key) as string)
-    }
-  }
+
+  const parsedParams = parseFromUrl(url.search)
+  const params = Object.entries(parsedParams).reduce(
+    (acc, [key, value]) => {
+      const castedValue = castValue(value)
+      if (PRIVATE_PARAMS.has(key)) privateParams[key] = castedValue
+      else acc[key] = castedValue
+      return acc
+    },
+    {} as Record<string, IValue>,
+  )
 
   const encrypted = await getEncryptedParams({ url })
-  params = { ...params, ...encrypted }
 
   return {
-    params,
+    params: { ...params, ...encrypted },
     download: privateParams[DOWNLOAD_PARAM] === true,
     force: privateParams[FORCE_REFETCH_PARAM] === true,
   }

--- a/docs/views/components/inputs/select.mdx
+++ b/docs/views/components/inputs/select.mdx
@@ -122,3 +122,40 @@ You can customize the text that is displayed in the dropdown with the following 
 	placeholder="Select a city..."
 />
 ```
+
+## Multiple selection
+
+You can also allow multiple selections by adding the `multiple` prop. This will display a checkbox next to each option that the user can select.
+
+```jsx
+<Select
+	query="cities"
+	param="city_ids"
+	multiple
+/>
+```
+
+When multiple selections are enabled, the parameter value will be an array of selected values. You can iterate over this array using the `{#each}` block in your queries.
+
+<CodeGroup>
+```jsx Your query
+SELECT *
+FROM cities
+WHERE
+{#each param('city_ids') as city, index}
+	{#if index > 0} OR {/if}
+	id = {city}
+{/each}
+```
+
+```sql Compiled SQL
+SELECT *
+FROM cities
+WHERE
+	id = 'NYC'
+	OR id = 'LA'
+	OR id = 'SF'
+```
+</CodeGroup>
+
+Check out [Queries Loops](/queries/logic/loops) for more information on how to iterate over arrays in queries.

--- a/packages/client/core/src/data/api.ts
+++ b/packages/client/core/src/data/api.ts
@@ -1,4 +1,4 @@
-import { format } from '@latitude-data/custom_types'
+import { formatAll } from '@latitude-data/custom_types'
 import { QueryParams } from '../stores/queries'
 import {
   DOWNLOAD_PARAM,
@@ -34,12 +34,20 @@ export class LatitudeApi {
   private cors: RequestMode = 'cors'
 
   static buildParams(params: AnyObject): string {
-    return Object.entries(params)
-      .map(([key, value]) => {
-        if (PRIVATE_PARAMS.has(key)) return `${key}=${value}`
+    const privateParams = Object.fromEntries(
+      Object.entries(params).filter(([key]) => PRIVATE_PARAMS.has(key)),
+    )
+    const regularParams = Object.fromEntries(
+      Object.entries(params).filter(([key]) => !PRIVATE_PARAMS.has(key)),
+    )
 
-        return `${key}=${format(value)}`
-      })
+    const formattedRegularParams = formatAll(regularParams)
+    const formattedPrivateParams = Object.entries(privateParams)
+      .map(([key, value]) => `${key}=${value}`)
+      .join('&')
+
+    return [formattedRegularParams, formattedPrivateParams]
+      .filter(Boolean)
       .join('&')
   }
 

--- a/packages/custom_types/src/rich_date.ts
+++ b/packages/custom_types/src/rich_date.ts
@@ -97,7 +97,11 @@ export class RichDate {
     }
 
     const date = parseDate(formattedValue, format, new Date())
-    return new RichDate(date, format)
+    const timezoneAgnosticDate = new Date(
+      Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()),
+    )
+
+    return new RichDate(timezoneAgnosticDate, format)
   }
 
   isRelative(): boolean {

--- a/packages/custom_types/src/type_parser.test.ts
+++ b/packages/custom_types/src/type_parser.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { format, parse } from '.' // Update the import path as necessary
+import { format, formatAll, parse, parseFromUrl } from '.' // Update the import path as necessary
 import { RichDate, RelativeDate } from '.' // Ensure the RichDate class is correctly imported
 
 describe('format', () => {
@@ -96,5 +96,34 @@ describe('parse', () => {
   it('decode URI components for unhandled types', () => {
     const encodedString = encodeURIComponent('Some encoded string')
     expect(parse(encodedString)).toBe('Some encoded string')
+  })
+})
+
+describe('formatAll', () => {
+  it('formats all values correctly', () => {
+    const params = {
+      foo: 'bar',
+      baz: [1, 2, 3],
+      qux: ['foo', 'bar', 'baz'],
+      date: new RichDate(new Date('2023-01-01')),
+      relativeDate: new RichDate(RelativeDate.Today),
+    }
+    expect(formatAll(params)).toBe(
+      'foo=bar&baz[]=1&baz[]=2&baz[]=3&qux[]=foo&qux[]=bar&qux[]=baz&date=2023-01-01:yyyy-MM-dd&relativeDate=_TODAY_:yyyy-MM-dd',
+    )
+  })
+})
+
+describe('parseFromUrl', () => {
+  it('parses all values correctly', () => {
+    const params =
+      'foo=bar&baz[]=$num:1&baz[]=$num:2&baz[]=$num:3&qux[]=$text:foo&qux[]=$text:bar&qux[]=$text:baz&date=$date:2023-01-01:yyyy-MM-dd&relativeDate=$date:_TODAY_:yyyy-MM-dd'
+    expect(parseFromUrl(params)).toEqual({
+      foo: 'bar',
+      baz: [1, 2, 3],
+      qux: ['foo', 'bar', 'baz'],
+      date: new RichDate(new Date('2023-01-01')),
+      relativeDate: new RichDate(RelativeDate.Today),
+    })
   })
 })


### PR DESCRIPTION
## Describe your changes
With the addition of the `multiple` prop, `Select` components can now support multiple item selection. When this prop is enabled, the associated parameter will be returned as an array, making them iterable from within queries. 

https://github.com/latitude-dev/latitude/assets/57395395/00e177ed-07ac-4568-956c-6de912cdc69c

Note: Select size is fixed in a different branch. Just ignore that for this PR.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have added thorough tests
- [x] I have updated the documentation if necessary
- [x] I have added a human-readable description of the changes for the release notes
- [x] I have included a recorded video capture of the feature manually tested

