### PR TITLE
Port pre-release adjustment from main to canary branch

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -3,7 +3,7 @@ name: Pre-Release
 on:
   push:
     branches:
-      - next
+      - canary
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,38 +132,38 @@ Changesets ensure that package versions are updated correctly before releasing o
 
 We publish Latitude packages on npmjs.com and GitHub, using [semantic versioning](https://semver.org/) to manage our package versions.
 
-There are two types of publications: `latest`, representing stable versions, and `next`, for pre-release versions.
+There are two types of publications: `latest`, representing stable versions, and `canary`, for pre-release versions.
 
 #### How to Do Pre-releases
 
-Our [pre-release.yml](./.github/workflow/pre-release.yml) CI workflow automatically publishes to the `next` distribution tag on npmjs.com when changes are merged into the `next` branch.
+Our [pre-release.yml](./.github/workflow/pre-release.yml) CI workflow automatically publishes to the `canary` distribution tag on npmjs.com when changes are merged into the `canary` branch.
 To make a pre-release, follow these steps:
 
-1. Switch to the `next` branch and run `git rebase main` to ensure it's up to date with the latest package versions.
-2. Branch off `next` for your changes.
-3. Enter the pre release mode by running `pnpm changeset pre enter next`.
+1. Switch to the `canary` branch and run `git rebase main` to ensure it's up to date with the latest package versions.
+2. Branch off `canary` for your changes.
+3. Enter the pre release mode by running `pnpm changeset pre enter canary`.
 3. Create a changeset for your modifications using `pnpm changeset`.
-4. Open a pull request on GitHub targeting the `next` branch.
+4. Open a pull request on GitHub targeting the `canary` branch.
 
-Once the pull request is merged, the CI will generate a PR with the changesets. Eventually, someone with permissions will merge this PR into `next`, triggering the publication of a pre-release.
+Once the pull request is merged, the CI will generate a PR with the changesets. Eventually, someone with permissions will merge this PR into `canary`, triggering the publication of a pre-release.
 
 #### Merging prereleases to main branch
 
 Once we are ready to release the pre-release to the main branch, we can merge
-the `next` branch into the `main` branch. This will trigger the release
+the `canary` branch into the `main` branch. This will trigger the release
 workflow to publish the pre-release to the `latest` distribution tag on
-npmjs.com. 
+npmjs.com.
 
 Here's how this workflow should be performed:
 
-1. Lock `next` branch to prevent new changes from being added.
-2. Open a PR from `next` to `main`.
-3. Rebase the PR to ensure it's up to date with the latest changes in main branch.
+1. "Do not merge more PRs into", remember we control PR merges.
+2. Open a PR from `canary` to `main`.
+3. Rebase the PR to ensure it's up to date with the latest changes in `main` branch.
 4. Run `pnpm changeset pre exit` to exit pre-release mode.
 5. This PR has to:
   - Keep all changes in `.changeset` folder
-  - Ensure no mentions to `next` packages are made in CHANGELOGs
-  - Ensure no changes to `package.json` version numbers are made. We want to keep the main branch version numbers as they.
+  - Ensure no mentions to `canary` packages are made in CHANGELOGs
+  - Ensure no changes to `package.json` version numbers are made. We want to keep the main branch version numbers as they are.
 6. Merge the PR into `main` branch.
 
 Once the PR is merged into the main branch, the CI will generate a PR with the changesets. Eventually, someone with permissions will merge this PR into `main`, triggering the publication of a release.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -44,8 +44,8 @@ CLI.command('start')
   .option('--template', 'Template to use for the Latitude app')
   .option('--port', 'Port to run the Latitude app on')
   .option(
-    '--next',
-    'Whether to display next releases of Latitude as available versions',
+    '--canary',
+    'Whether to display canary releases of Latitude as available versions',
   )
   .action(startCommand)
 
@@ -57,8 +57,8 @@ CLI.command('update')
   )
   .option('--fix', 'Installs the version defined in latitude.json')
   .option(
-    '--next',
-    'Whether to display next releases of Latitude as available versions',
+    '--canary',
+    'Whether to display canary releases of Latitude as available versions',
   )
   .action(updateCommand)
 

--- a/packages/cli/src/commands/start/index.ts
+++ b/packages/cli/src/commands/start/index.ts
@@ -38,13 +38,13 @@ export default async function startCommand({
   name,
   port,
   template,
-  next = false,
+  canary = false,
   open = false,
 }: {
   open: boolean
   port?: number
   name?: string
-  next?: boolean
+  canary?: boolean
   template?: TemplateUrl
 }) {
   const {
@@ -74,7 +74,7 @@ export default async function startCommand({
 
   config.rootDir = rootDir
 
-  await setupApp({ next })
+  await setupApp({ canary })
   await welcomeMessage()
 
   if (open) {

--- a/packages/cli/src/commands/update/index.ts
+++ b/packages/cli/src/commands/update/index.ts
@@ -11,14 +11,14 @@ import { select } from '@inquirer/prompts'
 import setRootDir from '$src/lib/decorators/setRootDir'
 
 async function askForAppVersion(
-  { next = false }: { next?: boolean } = { next: false },
+  { canary = false }: { canary?: boolean } = { canary: false },
 ) {
   let versions: string[] = DEFAULT_VERSION_LIST
   try {
     console.log('Fetching Latitude versions...')
     versions = await getLatitudeVersions({
       onFetch: () => cleanTerminal(),
-      next,
+      canary,
     })
   } catch {
     // Already handled in onError
@@ -34,13 +34,13 @@ async function askForAppVersion(
 }
 
 async function getVersions({
-  next = false,
+  canary = false,
   fix,
 }: {
-  next?: boolean
+  canary?: boolean
   fix: boolean
 }) {
-  const latitudeJson = await findOrCreateConfigFile({ next })
+  const latitudeJson = await findOrCreateConfigFile({ canary })
 
   if (fix) {
     return {
@@ -51,7 +51,7 @@ async function getVersions({
 
   let newVersion = null
   try {
-    newVersion = await askForAppVersion({ next })
+    newVersion = await askForAppVersion({ canary })
   } catch (error) {
     if (!error) {
       console.log('🙈 Mission aborted, when you are ready, try again')
@@ -73,12 +73,12 @@ async function getVersions({
 async function updateCommand(args: {
   fix?: boolean
   force?: boolean
-  next?: boolean
+  canary?: boolean
 }) {
   const fix = args.fix ?? false
   const force = args.force ?? false
-  const next = args.next ?? false
-  const { oldVersion, newVersion } = await getVersions({ next, fix })
+  const canary = args.canary ?? false
+  const { oldVersion, newVersion } = await getVersions({ canary, fix })
 
   if (!newVersion) process.exit(1)
 

--- a/packages/cli/src/lib/getAppVersions.test.ts
+++ b/packages/cli/src/lib/getAppVersions.test.ts
@@ -48,7 +48,7 @@ describe('getAppVersions with next flag', () => {
         const versions = [
           '1.0.0',
           '1.1.0',
-          '2.0.0-next.1',
+          '2.0.0-canary.1',
           '2.0.0-next.2',
           '2.0.0',
         ]
@@ -66,11 +66,11 @@ describe('getAppVersions with next flag', () => {
     vi.mocked(exec).mockRestore()
   })
 
-  it('should return next releases when the next flag is set to true', async () => {
-    const options = { next: true }
+  it('should return canary releases when the next flag is set to true', async () => {
+    const options = { canary: true }
     const results = await getLatitudeVersions(options)
 
-    const includesNextVersions = results.some((v) => v.includes('next'))
+    const includesNextVersions = results.some((v) => v.includes('canary'))
 
     expect(results).toBeInstanceOf(Array)
     expect(results.length).toBeGreaterThan(0)
@@ -78,7 +78,7 @@ describe('getAppVersions with next flag', () => {
   })
 
   it('should filter out next releases when the next flag is set to false', async () => {
-    const options = { next: false }
+    const options = { canary: false }
     const results = await getLatitudeVersions(options)
 
     const includesNextVersions = results.some((v) => v.includes('next'))

--- a/packages/cli/src/lib/getAppVersions.ts
+++ b/packages/cli/src/lib/getAppVersions.ts
@@ -23,14 +23,20 @@ export function getInstalledVersion(appDir: string) {
   return version
 }
 
+// Backwards Compatibility. before we called canary versions "next"
+const CANARY_VERSION = ['canary', 'next']
+
+function isCanary(version: string) {
+  return CANARY_VERSION.some((v) => version.includes(v))
+}
 export default async function getLatitudeVersions(
   {
     onFetch,
-    next = false,
+    canary = false,
   }: {
     onFetch?: () => void
-    next?: boolean
-  } = { next: false },
+    canary?: boolean
+  } = { canary: false },
 ) {
   const command = `npm view ${PACKAGE_NAME} versions --json`
 
@@ -46,9 +52,9 @@ export default async function getLatitudeVersions(
       let versions: string[] | undefined = undefined
       try {
         versions = JSON.parse(stdout)
-        versions = next
+        versions = canary
           ? versions
-          : versions?.filter((v: string) => !v.includes('next'))
+          : versions?.filter((v: string) => !isCanary(v))
       } catch (e) {
         reject(e)
       }

--- a/packages/cli/src/lib/latitudeConfig/create.ts
+++ b/packages/cli/src/lib/latitudeConfig/create.ts
@@ -7,13 +7,13 @@ import { onError } from '$src/utils'
 
 export default async function createConfigFile({
   version,
-  next = false,
+  canary = false,
 }: {
   version?: string
-  next?: boolean
+  canary?: boolean
 }): Promise<ConfigFile> {
   try {
-    version = version ?? (await getLatestVersion({ next }))
+    version = version ?? (await getLatestVersion({ canary }))
   } catch (error) {
     onError({
       error: error as Error,

--- a/packages/cli/src/lib/latitudeConfig/findOrCreate.ts
+++ b/packages/cli/src/lib/latitudeConfig/findOrCreate.ts
@@ -3,11 +3,11 @@ import findConfigFile, { ConfigFile } from './findConfigFile'
 import validate from './validate'
 
 export default async function findOrCreateConfigFile(
-  { next = false }: { next: boolean } = { next: false },
+  { canary = false }: { canary: boolean } = { canary: false },
 ): Promise<ConfigFile> {
   const config = findConfigFile()
   const validated = validate(config.data)
   if (validated.valid) return config
 
-  return createConfigFile({ next, version: config?.data?.version })
+  return createConfigFile({ canary, version: config?.data?.version })
 }

--- a/packages/cli/src/lib/latitudeConfig/getLatestVersion.ts
+++ b/packages/cli/src/lib/latitudeConfig/getLatestVersion.ts
@@ -2,10 +2,10 @@ import { onError } from '$src/utils'
 import getLatitudeVersions from '../getAppVersions'
 
 export default async function getLatestVersion(
-  { next = false }: { next?: boolean } = { next: false },
+  { canary = false }: { canary?: boolean } = { canary: false },
 ) {
   try {
-    const versions = await getLatitudeVersions({ next })
+    const versions = await getLatitudeVersions({ canary })
     const latestVersion = versions[0]
 
     if (!latestVersion) {

--- a/packages/cli/src/lib/setupApp/index.ts
+++ b/packages/cli/src/lib/setupApp/index.ts
@@ -7,9 +7,9 @@ import addPackageJson from '../addPackageJson'
 export type Props = { version?: string }
 
 export default async function setupApp(
-  { next = false }: { next?: boolean } = { next: false },
+  { canary = false }: { canary?: boolean } = { canary: false },
 ) {
-  const config = await findOrCreateConfigFile({ next })
+  const config = await findOrCreateConfigFile({ canary })
   await installLatitudeServer({ version: config.data.version })
   await installDependencies()
   addPackageJson()


### PR DESCRIPTION
## Describe your changes
I made these changes in `main` before https://github.com/latitude-dev/latitude/pull/443
But it doesn't make sense. We need these changes in canary to make the `.github/pre-release.yml` CI work and publish new canary versions I think


