### PR TITLE
Fix: Data types for DuckDB

### DIFF
--- a/.changeset/eighty-yaks-happen.md
+++ b/.changeset/eighty-yaks-happen.md
@@ -1,0 +1,5 @@
+---
+"@latitude-data/source-manager": patch
+---
+
+Fix: Loading the same source from the config file and from a query resulted in two different source instances.

--- a/.changeset/lovely-apricots-bake.md
+++ b/.changeset/lovely-apricots-bake.md
@@ -1,0 +1,5 @@
+---
+"@latitude-data/duckdb-connector": patch
+---
+
+DuckDB now returns the correct types

--- a/packages/connectors/duckdb/.gitignore
+++ b/packages/connectors/duckdb/.gitignore
@@ -1,1 +1,3 @@
 dist
+src/tests/dummyApp/table.csv
+src/tests/dummyApp/query.sql

--- a/packages/connectors/duckdb/package.json
+++ b/packages/connectors/duckdb/package.json
@@ -17,19 +17,21 @@
   "types": "dist/index.d.ts",
   "devDependencies": {
     "@latitude-data/eslint-config": "workspace:*",
-    "@latitude-data/typescript": "workspace:*",
     "@latitude-data/sql-compiler": "workspace:*",
-    "@types/mock-fs": "^4.13.4",
-    "mock-fs": "^5.2.0",
+    "@latitude-data/typescript": "workspace:*",
     "@rollup/plugin-typescript": "^11.1.6",
+    "@types/json2csv": "^5.0.7",
+    "@types/mock-fs": "^4.13.4",
     "@types/node": "^20.10.6",
+    "json2csv": "6.0.0-alpha.2",
+    "mock-fs": "^5.2.0",
+    "rollup": "^4.10.0",
     "vite-tsconfig-paths": "^4.3.1",
-    "vitest": "^1.6.0",
-    "rollup": "^4.10.0"
+    "vitest": "^1.6.0"
   },
   "dependencies": {
-    "@latitude-data/source-manager": "workspace:^",
     "@latitude-data/query_result": "workspace:^",
+    "@latitude-data/source-manager": "workspace:^",
     "duckdb-async": "^0.9.2"
   }
 }

--- a/packages/connectors/duckdb/src/data_types.test.ts
+++ b/packages/connectors/duckdb/src/data_types.test.ts
@@ -1,0 +1,74 @@
+import fs from 'fs'
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { Parser } from 'json2csv'
+import { CompiledQuery, SourceManager } from '@latitude-data/source-manager'
+import path from 'path'
+import { DataType } from '@latitude-data/query_result'
+import DuckdbConnector from '.'
+
+const QUERIES_DIR = 'src/tests/dummyApp'
+const FULL_QUERIES_DIR = path.join(__dirname, 'tests/dummyApp')
+
+function createTable(table: Record<string, unknown>[]) {
+  const parser = new Parser()
+  const csv = parser.parse(table)
+  fs.writeFileSync(`${QUERIES_DIR}/table.csv`, csv)
+}
+
+describe('data type detection', async () => {
+  beforeAll(() => {
+    fs.writeFileSync(
+      `${QUERIES_DIR}/query.sql`,
+      `SELECT * FROM read_csv_auto('${FULL_QUERIES_DIR}/table.csv')`,
+    )
+  })
+
+  afterAll(() => {
+    fs.unlinkSync(`${QUERIES_DIR}/query.sql`)
+    fs.unlinkSync(`${QUERIES_DIR}/table.csv`)
+  })
+
+  const sourceManager = new SourceManager(QUERIES_DIR)
+  const source = await sourceManager.loadFromConfigFile('source.yml')
+  const connector = new DuckdbConnector({ source, connectionParams: {} })
+  source._connector = connector
+
+  it('detects types from csv tables', async () => {
+    createTable([
+      {
+        id: 1,
+        name: 'Alice',
+        age: 20,
+        birthday: new Date('2022-01-01'),
+        isAlive: true,
+      },
+      {
+        id: 2,
+        name: 'Bob',
+        age: 30,
+        birthday: new Date('2022-02-02'),
+        isAlive: false,
+      },
+      {
+        id: 3,
+        name: 'Charlie',
+        age: 40,
+        birthday: new Date('2022-03-03'),
+        isAlive: true,
+      },
+    ])
+
+    const result = await source
+      .compileQuery({ queryPath: 'query' })
+      .then((compiledQuery: CompiledQuery) =>
+        source.runCompiledQuery(compiledQuery),
+      )
+    expect(result.fields).toEqual([
+      { name: 'id', type: DataType.Integer },
+      { name: 'name', type: DataType.String },
+      { name: 'age', type: DataType.Integer },
+      { name: 'birthday', type: DataType.Datetime },
+      { name: 'isAlive', type: DataType.Boolean },
+    ])
+  })
+})

--- a/packages/connectors/duckdb/src/tests/dummyApp/source.yml
+++ b/packages/connectors/duckdb/src/tests/dummyApp/source.yml
@@ -1,0 +1,1 @@
+type: duckdb

--- a/packages/source_manager/src/manager/index.test.ts
+++ b/packages/source_manager/src/manager/index.test.ts
@@ -8,13 +8,16 @@ describe('SourceManager', () => {
   it('does not load the same connector twice', async () => {
     const readFileSpy = vi.spyOn(fs, 'readFileSync')
     const factorySpy = vi.spyOn(factory, 'default')
+    const configPath = 'valid-source/source.yml'
     const query1Path = 'valid-source/query'
     const query2Path = 'valid-source/nested/query'
     const sourceManager = new SourceManager(QUERIES_DIR)
+    const source0 = await sourceManager.loadFromConfigFile(configPath)
     const source1 = await sourceManager.loadFromQuery(query1Path)
     const source2 = await sourceManager.loadFromQuery(query2Path)
 
     expect(readFileSpy).toHaveBeenCalledOnce()
+    expect(source0).toBe(source1)
     expect(source1).toBe(source2)
 
     await source1.compileQuery({ queryPath: 'valid-source/query' })

--- a/packages/source_manager/src/manager/index.ts
+++ b/packages/source_manager/src/manager/index.ts
@@ -91,7 +91,7 @@ export default class SourceManager {
       )
     }
 
-    const sourcePath = path.dirname(sourceFile)
+    const sourcePath = path.relative(this.queriesDir, path.dirname(sourceFile))
     if (!this.instances[sourcePath]) {
       this.buildSource({ sourcePath, sourceFile })
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -968,12 +968,18 @@ importers:
       '@rollup/plugin-typescript':
         specifier: ^11.1.6
         version: 11.1.6(rollup@4.10.0)(tslib@2.6.2)(typescript@5.4.3)
+      '@types/json2csv':
+        specifier: ^5.0.7
+        version: 5.0.7
       '@types/mock-fs':
         specifier: ^4.13.4
         version: 4.13.4
       '@types/node':
         specifier: ^20.10.6
         version: 20.10.6
+      json2csv:
+        specifier: 6.0.0-alpha.2
+        version: 6.0.0-alpha.2
       mock-fs:
         specifier: ^5.2.0
         version: 5.2.0
@@ -10211,6 +10217,10 @@ packages:
       file-system-cache: 2.3.0
     dev: true
 
+  /@streamparser/json@0.0.6:
+    resolution: {integrity: sha512-vL9EVn/v+OhZ+Wcs6O4iKE9EUpwHUqHmCtNUMWjqp+6dr85+XPOSGTEsqYNq1Vn04uk9SWlOVmx9J48ggJVT2Q==}
+    dev: true
+
   /@sveltejs/adapter-auto@3.0.0(@sveltejs/kit@2.5.0):
     resolution: {integrity: sha512-UNWSs/rOReBRfI/xFwSO2WYF1a7PT74SrWOHJmSNLY3Lq+zbH0uuvnlP+TmrTUBvOTkou3WJDjL6lK3n6aOUgQ==}
     peerDependencies:
@@ -10803,6 +10813,12 @@ packages:
 
   /@types/json-schema@7.0.12:
     resolution: {integrity: sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==}
+    dev: true
+
+  /@types/json2csv@5.0.7:
+    resolution: {integrity: sha512-Ma25zw9G9GEBnX8b12R4EYvnFT6dBh8L3jwsN5EUFXa+fl2dqmbLDbNWN0XuQU3rSXdsbBeCYjI9uHU2PUBxhA==}
+    dependencies:
+      '@types/node': 20.12.12
     dev: true
 
   /@types/json5@0.0.29:
@@ -16692,6 +16708,7 @@ packages:
   /iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
+    requiresBuild: true
     dependencies:
       safer-buffer: 2.1.2
 
@@ -18083,6 +18100,16 @@ packages:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
     dev: true
 
+  /json2csv@6.0.0-alpha.2:
+    resolution: {integrity: sha512-nJ3oP6QxN8z69IT1HmrJdfVxhU1kLTBVgMfRnNZc37YEY+jZ4nU27rBGxT4vaqM/KUCavLRhntmTuBFqZLBUcA==}
+    engines: {node: '>= 12', npm: '>= 6.13.0'}
+    hasBin: true
+    dependencies:
+      '@streamparser/json': 0.0.6
+      commander: 6.2.1
+      lodash.get: 4.4.2
+    dev: true
+
   /json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
     hasBin: true
@@ -18335,6 +18362,10 @@ packages:
     requiresBuild: true
     dev: false
     optional: true
+
+  /lodash.get@4.4.2:
+    resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
+    dev: true
 
   /lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
@@ -22131,6 +22162,7 @@ packages:
 
   /safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+    requiresBuild: true
 
   /sander@0.5.1:
     resolution: {integrity: sha512-3lVqBir7WuKDHGrKRDn/1Ye3kwpXaDOMsiRP1wd6wpZW56gJhsbp5RqQpA6JG/P+pkXizygnr1dKR8vzWaVsfA==}


### PR DESCRIPTION
## Describe your changes

DuckDB was returning all result fields as "strings". Now it actually reads the types from the query result.

Before vs after:

https://github.com/latitude-dev/latitude/assets/57395395/070bb7a1-f381-4d0a-9921-ceaae202b6ac


## Checklist before requesting a review
- [x] I have added thorough tests
- [ ] I have updated the documentation if necessary
- [x] I have added a human-readable description of the changes for the release notes
- [x] I have included a recorded video capture of the feature manually tested

