### PR TITLE
Avoid breaking CLI because telemetry service is down

### DIFF
--- a/.changeset/brave-buses-beam.md
+++ b/.changeset/brave-buses-beam.md
@@ -1,0 +1,6 @@
+---
+"@latitude-data/react": minor
+"@latitude-data/cli": minor
+---
+
+Fix CLI breking when telemetry api is down

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@latitude-data/duckdb-connector": "workspace:*"
+    "@latitude-data/duckdb-connector": "workspace:*",
+    "@latitude-data/postgresql-connector": "workspace:*"
   }
 }

--- a/packages/cli/src/lib/telemetry/index.ts
+++ b/packages/cli/src/lib/telemetry/index.ts
@@ -1,5 +1,6 @@
 import RudderAnalytics from '@rudderstack/rudder-sdk-node'
 import config from '$src/config'
+import * as Sentry from '@sentry/node'
 import configStore from '$src/lib/configStore'
 import crypto from 'crypto'
 import os from 'os'
@@ -78,11 +79,15 @@ export class Telemetry {
   }
 
   private async _track<T extends TelemetryEventType>(event: TelemetryEvent<T>) {
-    this.client?.track({
-      anonymousId: this.anonymousId,
-      event: event.event,
-      properties: event.properties,
-    })
+    try {
+      this.client?.track({
+        anonymousId: this.anonymousId,
+        event: event.event,
+        properties: event.properties,
+      })
+    } catch (e) {
+      Sentry.captureException(e)
+    }
   }
 
   private identifyAnonymous() {

--- a/packages/client/react/rollup.config.mjs
+++ b/packages/client/react/rollup.config.mjs
@@ -14,6 +14,7 @@ const EXTERNAL_DEPENDENCIES = [
   '@radix-ui/react-slot',
   '@radix-ui/react-label',
   'react-table',
+  'use-prefers-color-scheme',
   'lodash-es',
   'echarts/core',
   'echarts/renderers',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@latitude-data/duckdb-connector':
         specifier: workspace:*
         version: link:packages/connectors/duckdb
+      '@latitude-data/postgresql-connector':
+        specifier: workspace:*
+        version: link:packages/connectors/postgresql
     devDependencies:
       '@changesets/cli':
         specifier: ^2.27.1


### PR DESCRIPTION
## Describe your changes
We want the CLI to continue working even when there's no internet or the telemetry system is not responding.

## Issue ticket number and link
https://github.com/latitude-dev/latitude/issues/453


