### PR TITLE
Show app version and CLI version when running latitude -v

### DIFF
--- a/.changeset/little-frogs-retire.md
+++ b/.changeset/little-frogs-retire.md
@@ -1,0 +1,5 @@
+---
+"@latitude-data/cli": minor
+---
+
+In CLI show app version and CLI version

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -4,6 +4,7 @@ import buildCommand from './commands/build'
 import cancelCommand from './commands/cloud/cancel'
 import config from './config'
 import credentialsCommand from './commands/credentials'
+import versionCommand from './commands/version'
 import deployCommand from './commands/cloud/deploy'
 import destroyCommand from './commands/cloud/destroy'
 import devCommand from './commands/dev'
@@ -27,8 +28,15 @@ initSentry()
 
 const CLI = sade('latitude')
 
-CLI.version(process.env.PACKAGE_VERSION ?? 'development')
-  .option('--verbose', 'Enables verbose console logs')
+// TODO: find a better way
+//
+// I opened an issue in Sade's repo:
+// https://github.com/lukeed/sade/issues/58
+//
+// @ts-expect-error
+CLI['_version'] = versionCommand
+
+CLI.option('--verbose', 'Enables verbose console logs')
   .option('--simulate-pro', 'Enable pro mode in development')
   .option('--tty', 'Enables or disables TTY mode.')
 
@@ -165,7 +173,7 @@ async function init() {
     process.exit(1)
   }
 
-  argv?.handler.apply(null, argv?.args)
+  argv?.handler?.apply?.(null, argv?.args)
 }
 
 init()

--- a/packages/cli/src/commands/version/index.ts
+++ b/packages/cli/src/commands/version/index.ts
@@ -1,0 +1,25 @@
+import colors from 'picocolors'
+import setRootDir from '$src/lib/decorators/setRootDir'
+import boxedMessage from '$src/lib/boxedMessage'
+import findOrCreateConfigFile from '$src/lib/latitudeConfig/findOrCreate'
+
+function versionLine({ name, version }: { name: string; version: string }) {
+  return `${colors.blue(`${name} version: `)} ${colors.green(version)}`
+}
+async function showVersions() {
+  const latitudeJson = await findOrCreateConfigFile()
+  const appVersion = latitudeJson.data.version
+  boxedMessage({
+    color: 'green',
+    title: 'Latitude versions',
+    text: `
+      ${versionLine({
+        name: 'CLI',
+        version: process.env.PACKAGE_VERSION ?? 'development',
+      })}
+      ${versionLine({ name: 'App', version: appVersion! })}
+    `,
+  })
+}
+
+export default setRootDir(showVersions)


### PR DESCRIPTION
## Describe your changes
☝️ That

## Issue
https://github.com/latitude-dev/latitude/issues/452

![image](https://github.com/latitude-dev/latitude/assets/49499/4b9d7b3f-c7af-4c2a-a1b8-ce8ea1522ffe)


## Sade hack
I had to hack sade (our cli package) because I don't see a way of defining a custom version method. 
I opened an issue in their repo
https://github.com/lukeed/sade/issues/58

