### PR TITLE
Temporary change template url

### DIFF
--- a/.changeset/shaggy-stingrays-vanish.md
+++ b/.changeset/shaggy-stingrays-vanish.md
@@ -1,0 +1,5 @@
+---
+"@latitude-data/cli": minor
+---
+
+Link temporarily to another template repo

--- a/packages/cli/src/commands/start/cloneTemplate.ts
+++ b/packages/cli/src/commands/start/cloneTemplate.ts
@@ -6,7 +6,11 @@ import { TemplateUrl } from './questions'
 
 const TEMPLATE_URL: Record<TemplateUrl, string> = {
   [TemplateUrl.default]: `${LATITUDE_GITHUB_SLUG}/template`,
-  [TemplateUrl.duckdb]: `${LATITUDE_GITHUB_SLUG}/sample-duckdb`,
+  // TODO: restore duckdb repo
+  //
+  // We don't have write permissions to this repo. Only Gerard has.
+  // [TemplateUrl.duckdb]: `${LATITUDE_GITHUB_SLUG}/sample-duckdb`,
+  [TemplateUrl.duckdb]: `${LATITUDE_GITHUB_SLUG}/sample-netflix`,
 }
 
 export default async function cloneTemplate({


### PR DESCRIPTION
## Describe your changes
We made a breaking change with the way we ref queries and we need to update the template. The problem is the person with access to the template repo is available so we would use another repo temporarily


