### PR TITLE
Batch query support batch for any connectors

### DIFF
--- a/.changeset/flat-meals-compete.md
+++ b/.changeset/flat-meals-compete.md
@@ -1,0 +1,5 @@
+---
+"@latitude-data/source-manager": minor
+---
+
+Added support for batching queries to all connectors

--- a/.changeset/tasty-chicken-knock.md
+++ b/.changeset/tasty-chicken-knock.md
@@ -1,0 +1,6 @@
+---
+"@latitude-data/athena-connector": patch
+"@latitude-data/mssql-connector": patch
+---
+
+Added a specific implementation for query pagination

--- a/packages/connectors/athena/src/index.ts
+++ b/packages/connectors/athena/src/index.ts
@@ -109,6 +109,13 @@ export default class AthenaConnector extends BaseConnector<ConnectionParams> {
     }
   }
 
+  protected paginateQuery(sql: string, limit: number, offset: number): string {
+    // Older Athena versions do not support LIMIT and OFFSET
+    return `SELECT * FROM (SELECT ROW_NUMBER() OVER() as _rn, * FROM (${sql})) WHERE _rn > BETWEEN ${offset} AND ${
+      offset + limit
+    }`
+  }
+
   private async checkQueryExequtionStateAndGetData(
     QueryExecutionId: string,
   ): Promise<QueryResult> {


### PR DESCRIPTION
## Describe your changes

Materializing queries currently requires fetching them in batches, but only the PostgreSQL connector has a ﻿`batchQuery` implementation. This means that any other source will fail if attempted.

Added a default `paginateQuery` function to the Base Connector that wraps any given query with a LIMIT and an OFFSET. Connectors may redefine this function if their syntax is different.

Then, added a default `batchQuery` implementation, where it just runs paginated queries one by one to the source until no more results are returned.

Not the most efficient process, but it's now supported by any connector! We can still redefine the `batchQuery` method for specific connectors to improve them one by one if we need so.

## Checklist before requesting a review
- [ ] I have added thorough tests
- [ ] I have updated the documentation if necessary
- [ ] I have added a human-readable description of the changes for the release notes
- [ ] I have included a recorded video capture of the feature manually tested

