### PR TITLE
Compiler spread support

### DIFF
--- a/.changeset/brave-carpets-drum.md
+++ b/.changeset/brave-carpets-drum.md
@@ -1,0 +1,5 @@
+---
+"@latitude-data/sql-compiler": minor
+---
+
+Added support for spread syntax

--- a/packages/connectors/compiler/src/compiler/logic/nodes/objectExpression.ts
+++ b/packages/connectors/compiler/src/compiler/logic/nodes/objectExpression.ts
@@ -2,12 +2,7 @@ import { getLogicNodeMetadata, resolveLogicNode } from '..'
 import errors from '../../../error/errors'
 import { mergeMetadata } from '../../utils'
 import { ReadNodeMetadataProps, type ResolveNodeProps } from '../types'
-import {
-  Property,
-  SpreadElement,
-  type Identifier,
-  type ObjectExpression,
-} from 'estree'
+import { type Identifier, type ObjectExpression } from 'estree'
 
 /**
  * ### ObjectExpression
@@ -21,23 +16,35 @@ export async function resolve({
 }: ResolveNodeProps<ObjectExpression>) {
   const resolvedObject: { [key: string]: any } = {}
   for (const prop of node.properties) {
-    if (prop.type !== 'Property') {
-      throw raiseError(errors.invalidObjectKey, node)
+    if (prop.type === 'SpreadElement') {
+      const spreadObject = await resolveLogicNode({
+        node: prop.argument,
+        scope,
+        raiseError,
+        ...props,
+      })
+      if (typeof spreadObject !== 'object') {
+        raiseError(errors.invalidSpreadInObject(typeof spreadObject), prop)
+      }
+      Object.entries(spreadObject as object).forEach(([key, value]) => {
+        resolvedObject[key] = value
+      })
+      continue
     }
-    const key = prop.key as Identifier
-    const value = await resolveLogicNode({
-      node: prop.value,
-      scope,
-      raiseError,
-      ...props,
-    })
-    resolvedObject[key.name] = value
+    if (prop.type === 'Property') {
+      const key = prop.key as Identifier
+      const value = await resolveLogicNode({
+        node: prop.value,
+        scope,
+        raiseError,
+        ...props,
+      })
+      resolvedObject[key.name] = value
+      continue
+    }
+    throw raiseError(errors.invalidObjectKey, prop)
   }
   return resolvedObject
-}
-
-function isProperty(prop: Property | SpreadElement): prop is Property {
-  return prop.type === 'Property'
 }
 
 export async function readMetadata({
@@ -45,18 +52,28 @@ export async function readMetadata({
   ...props
 }: ReadNodeMetadataProps<ObjectExpression>) {
   const propertiesMetadata = await Promise.all(
-    node.properties.filter(isProperty).map((prop) =>
-      Promise.all([
-        getLogicNodeMetadata({
-          node: prop.key,
-          ...props,
-        }),
-        getLogicNodeMetadata({
-          node: prop.value,
-          ...props,
-        }),
-      ]),
-    ),
+    node.properties
+      .map((prop) => {
+        if (prop.type === 'SpreadElement') {
+          return getLogicNodeMetadata({
+            node: prop.argument,
+            ...props,
+          })
+        }
+        if (prop.type === 'Property') {
+          return Promise.all([
+            getLogicNodeMetadata({
+              node: prop.key,
+              ...props,
+            }),
+            getLogicNodeMetadata({
+              node: prop.value,
+              ...props,
+            }),
+          ])
+        }
+      })
+      .filter((p) => p !== undefined),
   )
 
   return mergeMetadata(...propertiesMetadata.flat())

--- a/packages/connectors/compiler/src/compiler/utils.ts
+++ b/packages/connectors/compiler/src/compiler/utils.ts
@@ -40,3 +40,14 @@ export function emptyMetadata(): QueryMetadata {
     sqlHash: undefined,
   }
 }
+
+export function isIterable(obj: unknown): obj is Iterable<unknown> {
+  return (obj as Iterable<unknown>)?.[Symbol.iterator] !== undefined
+}
+
+export async function hasContent(iterable: Iterable<unknown>) {
+  for await (const _ of iterable) {
+    return true
+  }
+  return false
+}

--- a/packages/connectors/compiler/src/error/errors.ts
+++ b/packages/connectors/compiler/src/error/errors.ts
@@ -112,6 +112,14 @@ export default {
     code: 'invalid-object-key',
     message: 'Invalid object key',
   },
+  invalidSpreadInObject: (property: string) => ({
+    code: 'invalid-spread-in-object',
+    message: `Property '${property}' is not valid for spreading`,
+  }),
+  invalidSpreadInArray: (element: string) => ({
+    code: 'invalid-spread-in-array',
+    message: `Element '${element}' is not iterable`,
+  }),
   unsupportedOperator: (operator: string) => ({
     code: 'unsupported-operator',
     message: `Unsupported operator: ${operator}`,
@@ -139,7 +147,7 @@ export default {
   }),
   notAFunction: (objectType: string) => ({
     code: 'not-a-function',
-    message: `Object '${objectType}' is callable`,
+    message: `Object '${objectType}' is not callable`,
   }),
   functionCallError: (err: unknown) => {
     const error = err as Error


### PR DESCRIPTION
## Describe your changes

Added spread support on queries custom logic.

Also, improved `#each` block to support any iterator element, not just Arrays and Strings.

```jsx
{ selectedCities = param('cities_selector', []) }
{ cities = [  'bcn', 'nyc', ...selectedCities ] } /* Array created using spread */

SELECT *
FROM users
WHERE city IN (
{#each cities as name, index}
  {name} {#if index == cities.length - 1} , {/if}
{/each}
)
```
