### PR TITLE
Minor/improve vscode sql highlighting

### DIFF
--- a/.changeset/new-lies-listen.md
+++ b/.changeset/new-lies-listen.md
@@ -1,0 +1,5 @@
+---
+"latitude-vscode": patch
+---
+
+Improved syntax highlighting for LatitudeSQL files

--- a/tools/latitude-vscode/src/syntaxes/latitudeSql.tmLanguage.yaml
+++ b/tools/latitude-vscode/src/syntaxes/latitudeSql.tmLanguage.yaml
@@ -4,5 +4,86 @@ scopeName: source.latitudeSql
 fileTypes: [sql, latitudeSql]
 patterns:
   - include: 'source.sql'
+  - include: '#logic-block'
+
+repository:
+  logic-block:
+    name: 'meta.embedded.logic.latitudeSql'
+    patterns:
+      - include: '#open-block' # {# … }
+      - include: '#else-block' # {: … }
+      - include: '#close-block' # {/ … }
+      - include: '#define-block' # {@ … }
+      - include: '#mustache-block' # { … }
+
+  open-block:
+    name: 'meta.embedded.structure.open.latitudeSql'
+    begin: '(?<!\\)({#\b\w+\b)'
+    end: '(})'
+    beginCaptures:
+      '1':
+        name: 'keyword.control.flow'
+    endCaptures:
+      '1':
+        name: 'keyword.control.flow'
+    patterns:
+      - include: '#custom-js-expression'
+
+  else-block:
+    name: 'meta.embedded.structure.else.latitudeSql'
+    begin: '(?<!\\)({:\b\w+\b)'
+    end: '(})'
+    beginCaptures:
+      '1':
+        name: 'keyword.control.flow'
+    endCaptures:
+      '1':
+        name: 'keyword.control.flow'
+    patterns:
+      - include: '#custom-js-expression'
+
+  close-block:
+    name: 'meta.embedded.structure.close.latitudeSql'
+    begin: '(?<!\\)({/\b\w+\b)'
+    end: '(})'
+    beginCaptures:
+      '1':
+        name: 'keyword.control.flow'
+    endCaptures:
+      '1':
+        name: 'keyword.control.flow'
+    patterns:
+      - include: '#custom-js-expression'
+
+  define-block:
+    name: 'meta.embedded.definition.latitudeSql'
+    begin: '(?<!\\)({@\b\w+\b)'
+    end: '(})'
+    beginCaptures:
+      '1':
+        name: 'constant.character.set.regexp strong'
+    endCaptures:
+      '1':
+        name: 'constant.character.set.regexp strong'
+    patterns:
+      - include: '#custom-js-expression'
+
+  mustache-block:
+    name: 'meta.embedded.logic.latitudeSql emphasis'
+    begin: '(?<!\\)({)'
+    end: '(})'
+    beginCaptures:
+      '1':
+        name: 'keyword.control'
+    endCaptures:
+      '1':
+        name: 'keyword.control' 
+    patterns:
+      - include: '#custom-js-expression'
+  
+  custom-js-expression:
+    name: 'meta.embedded.logic.js.latitudeSql'
+    patterns:
+      - include: 'source.js'
 
 ...


### PR DESCRIPTION
## Describe your changes

Improved syntax on Latitude queries when using Latitude's vscode extension, to better visualize the query's logic and code intentions. Now, Latitude blocks will show actual JS syntax instead of SQL, and block brackets are properly highlighted too. Also, logic blocks that can interpolate content into the query are shown in Italics.

### BEFORE vs NOW
<div>
<img src="https://github.com/latitude-dev/latitude/assets/57395395/ea84f509-94e4-4986-96d9-471afbfa982b" width="300px" />
<img src="https://github.com/latitude-dev/latitude/assets/57395395/a55053ea-0270-4283-9e9b-51fac6d61c06" width="300px" />
</div>

Note: These colors are from VSCode's default Dark Theme+. Other themes may redefine these colors.

### Full scope of syntax:
![image](https://github.com/latitude-dev/latitude/assets/57395395/cf5d65a2-0080-4de3-9374-d5ca647d2a4a)
