### PR TITLE
Fix showing latitude -v version outside a latitude app

### DIFF
--- a/.changeset/twelve-bottles-attend.md
+++ b/.changeset/twelve-bottles-attend.md
@@ -1,0 +1,5 @@
+---
+"@latitude-data/cli": patch
+---
+
+Fix show Latitude CLI version outside a latitude project

--- a/packages/cli/core/src/cli.ts
+++ b/packages/cli/core/src/cli.ts
@@ -1,4 +1,13 @@
 #!/usr/bin/env node
+import process from 'process'
+
+/*
+ * Avoid shwing deprecation warnings to users
+ * for internal packages
+ */
+if (process.env.NODE_ENV === 'production') {
+  process.removeAllListeners('warning')
+}
 
 import buildCommand from './commands/build'
 import cancelCommand from './commands/cloud/cancel'

--- a/packages/cli/core/src/commands/start/cloneTemplate.ts
+++ b/packages/cli/core/src/commands/start/cloneTemplate.ts
@@ -6,11 +6,7 @@ import { TemplateUrl } from './questions'
 
 const TEMPLATE_URL: Record<TemplateUrl, string> = {
   [TemplateUrl.default]: `${LATITUDE_GITHUB_SLUG}/template`,
-  // TODO: restore duckdb repo
-  //
-  // We don't have write permissions to this repo. Only Gerard has.
-  // [TemplateUrl.duckdb]: `${LATITUDE_GITHUB_SLUG}/sample-duckdb`,
-  [TemplateUrl.duckdb]: `${LATITUDE_GITHUB_SLUG}/sample-netflix`,
+  [TemplateUrl.duckdb]: `${LATITUDE_GITHUB_SLUG}/sample-duckdb`,
 }
 
 export default async function cloneTemplate({

--- a/packages/cli/core/src/commands/version/index.ts
+++ b/packages/cli/core/src/commands/version/index.ts
@@ -1,5 +1,5 @@
+import fsExtra from 'fs-extra'
 import colors from 'picocolors'
-import setRootDir from '$src/lib/decorators/setRootDir'
 import boxedMessage from '$src/lib/boxedMessage'
 import findOrCreateConfigFile from '$src/lib/latitudeConfig/findOrCreate'
 import { getInstalledVersion } from '$src/lib/versionManagement/appVersion'
@@ -8,7 +8,12 @@ import config from '$src/config'
 function versionLine({ name, version }: { name: string; version: string }) {
   return `${colors.blue(`${name} version: `)} ${colors.green(version)}`
 }
-async function showVersions() {
+
+function cliVersion() {
+  return process.env.PACKAGE_VERSION ?? 'development'
+}
+
+async function showVersionsInApp() {
   const latitudeJson = await findOrCreateConfigFile()
   const appVersion = latitudeJson.data.version
   const installed = getInstalledVersion(config.rootDir)
@@ -16,10 +21,7 @@ async function showVersions() {
     color: 'green',
     title: 'Latitude versions',
     text: `
-      ${versionLine({
-        name: 'CLI',
-        version: process.env.PACKAGE_VERSION ?? 'development',
-      })}
+      ${versionLine({ name: 'CLI', version: cliVersion() })}
       ${versionLine({ name: 'App (latitude.json)', version: appVersion! })}
       ${
         installed
@@ -35,4 +37,18 @@ async function showVersions() {
   })
 }
 
-export default setRootDir(showVersions)
+function showVersions() {
+  if (!fsExtra.existsSync(config.latitudeJsonPath)) {
+    return boxedMessage({
+      color: 'green',
+      title: 'Latitude CLI version',
+      text: `
+      ${versionLine({ name: 'CLI', version: cliVersion() })}
+    `,
+    })
+  }
+
+  showVersionsInApp()
+}
+
+export default showVersions


### PR DESCRIPTION
# WHAT?
We did a refactor of the Latitude --version command and we broke the use case of just showing the CLI version when the user is not in a latitude project. Now we check if there is a latitude.json file in the folder before showing latitude.json app version and installed version.


## The bug
```
latitude -v
```
Display this outside a latitude project 
![image](https://github.com/latitude-dev/latitude/assets/49499/f6cefa7b-8fcb-4393-bcdf-5018bd52eb0f)

After the fix show just the CLI version
![image](https://github.com/latitude-dev/latitude/assets/49499/371ac6f4-9f6b-4a53-b7d4-d3f4b96ea17b)

