### PR TITLE
CLI: Only ignore deprecation warnings

### DIFF
--- a/.changeset/swift-ligers-nail.md
+++ b/.changeset/swift-ligers-nail.md
@@ -1,0 +1,5 @@
+---
+"@latitude-data/cli": patch
+---
+
+Only ignore deprecation warnings. Any other warning will still be logged

--- a/packages/cli/core/src/cli.ts
+++ b/packages/cli/core/src/cli.ts
@@ -5,9 +5,14 @@ import process from 'process'
  * Avoid shwing deprecation warnings to users
  * for internal packages
  */
-if (process.env.NODE_ENV === 'production') {
-  process.removeAllListeners('warning')
-}
+const onWarnings = process.rawListeners?.('warning')
+process.removeAllListeners('warning')
+process.on('warning', (warning) => {
+  if (warning.name === 'DeprecationWarning') {
+    return
+  }
+  onWarnings?.map((fn) => fn(warning))
+})
 
 import buildCommand from './commands/build'
 import cancelCommand from './commands/cloud/cancel'


### PR DESCRIPTION
## Describe your changes

Instead of removing all warning events, I added a middleware that filters out only deprecation warnings, and keeps any other.
