### PR TITLE
Fix: Handle nullable datetimes in BigQuery

### DIFF
--- a/.changeset/short-wasps-nail.md
+++ b/.changeset/short-wasps-nail.md
@@ -1,0 +1,5 @@
+---
+"@latitude-data/bigquery-connector": patch
+---
+
+Getting Date/DateTime columns with null results no longer throws an error

--- a/packages/connectors/bigquery/src/index.ts
+++ b/packages/connectors/bigquery/src/index.ts
@@ -128,7 +128,7 @@ export default class BigQueryConnector extends BaseConnector<ConnectionParams> {
         if (!field) return value
 
         if (field.type === DataType.Datetime) {
-          return (value as { value: unknown })['value']
+          return (value as { value: unknown })?.['value']
         } else {
           return value
         }


### PR DESCRIPTION
## Describe your changes

Getting Date/DateTime columns with null results no longer throws an error