### PR TITLE
Temp parquet files

### DIFF
--- a/.changeset/cuddly-baboons-help.md
+++ b/.changeset/cuddly-baboons-help.md
@@ -1,0 +1,6 @@
+---
+"@latitude-data/source-manager": patch
+"@latitude-data/storage-driver": patch
+---
+
+Parquet files will be stored in a temporal path while materialization is still in process. Only when it finishes, it will then be moved to the actual path.

--- a/packages/storage_driver/src/drivers/base.ts
+++ b/packages/storage_driver/src/drivers/base.ts
@@ -23,5 +23,8 @@ export abstract class StorageDriver {
     encoding?: T,
   ): Promise<T extends undefined ? Buffer : string>
 
+  abstract move(from: string, to: string): Promise<void>
+  abstract delete(path: string): Promise<void>
+
   abstract createWriteStream(path: string): Promise<Writable>
 }

--- a/packages/storage_driver/src/drivers/disk/DiskDriver.test.ts
+++ b/packages/storage_driver/src/drivers/disk/DiskDriver.test.ts
@@ -121,4 +121,28 @@ describe('DiskDriver', () => {
     const content = fs.readFileSync('/mocked/path/file.txt')
     expect(content.toString()).toBe('hello world')
   })
+
+  it('should move a file', async () => {
+    const fromPath = '/mocked/path/from.txt'
+    const toPath = '/mocked/path/to.txt'
+    mockFs({
+      '/mocked/path': {
+        'from.txt': 'content',
+      },
+    })
+    await driver.move(fromPath, toPath)
+    expect(fs.existsSync(toPath)).toBe(true)
+    expect(fs.existsSync(fromPath)).toBe(false)
+  })
+
+  it('should not move a file if it does not exist', async () => {
+    const fromPath = '/mocked/path/from.txt'
+    const toPath = '/mocked/path/to.txt'
+    mockFs({
+      '/mocked/path': {},
+    })
+    await driver.move(fromPath, toPath)
+    expect(fs.existsSync(toPath)).toBe(false)
+    expect(fs.existsSync(fromPath)).toBe(false)
+  })
 })

--- a/packages/storage_driver/src/drivers/disk/index.ts
+++ b/packages/storage_driver/src/drivers/disk/index.ts
@@ -85,4 +85,20 @@ export class DiskDriver extends StorageDriver {
     await this.createDirIfNotExists(filepath)
     return fs.createWriteStream(await this.resolveUrl(filepath))
   }
+
+  async move(from: string, to: string): Promise<void> {
+    const fromPath = await this.resolveUrl(from)
+    if (!fs.existsSync(fromPath)) return
+
+    await this.createDirIfNotExists(to)
+    const toPath = await this.resolveUrl(to)
+
+    fs.renameSync(fromPath, toPath)
+  }
+
+  async delete(filepath: string): Promise<void> {
+    const filePath = await this.resolveUrl(filepath)
+    if (!fs.existsSync(filePath)) return
+    fs.unlinkSync(filePath)
+  }
 }

--- a/packages/storage_driver/src/drivers/s3/index.ts
+++ b/packages/storage_driver/src/drivers/s3/index.ts
@@ -7,6 +7,8 @@ import {
   GetObjectCommand,
   PutObjectCommand,
   HeadObjectCommand,
+  CopyObjectCommand,
+  DeleteObjectCommand,
 } from '@aws-sdk/client-s3'
 import { Upload } from '@aws-sdk/lib-storage'
 import { PassThrough } from 'stream'
@@ -131,6 +133,23 @@ export class S3Driver extends StorageDriver {
       return buffer.toString(encoding) as T extends undefined ? Buffer : string
     }
     return buffer as T extends undefined ? Buffer : string
+  }
+
+  async move(from: string, to: string): Promise<void> {
+    await this.client.send(
+      new CopyObjectCommand({
+        Bucket: this.bucket,
+        Key: to,
+        CopySource: this.bucket + '/' + from,
+      }),
+    )
+    await this.delete(from)
+  }
+
+  async delete(filepath: string): Promise<void> {
+    await this.client.send(
+      new DeleteObjectCommand({ Bucket: this.bucket, Key: filepath }),
+    )
   }
 
   async createWriteStream(filepath: string): Promise<Writable> {


### PR DESCRIPTION
## Describe your changes

To avoid keeping broken parquet files, or displaying errors while re-materializing queries, the materialization process will create the parquet files in temp directories. Only when the materialization finished successfully, then the temp file will be moved to the final path where it has to be stored.

## Checklist before requesting a review
- [x] I have added thorough tests
- [ ] I have updated the documentation if necessary
- [x] I have added a human-readable description of the changes for the release notes
- [ ] I have included a recorded video capture of the feature manually tested

