### PR TITLE
CLI Table fixes

### DIFF
--- a/.changeset/wise-cheetahs-develop.md
+++ b/.changeset/wise-cheetahs-develop.md
@@ -1,0 +1,5 @@
+---
+"@latitude-data/display_table": patch
+---
+
+Added Scrollable containers for queries and errors.

--- a/packages/cli/display_table/package.json
+++ b/packages/cli/display_table/package.json
@@ -33,12 +33,13 @@
     "@rollup/plugin-typescript": "^11.1.6",
     "@types/node": "^20.12.12",
     "@types/react": "^18.2.74",
-    "chalk": "^5.2.0",
+    "chalk": "^5.3.0",
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "prettier": "^2.8.7",
     "rollup": "^4.10.0",
     "ts-node": "^10.9.1",
+    "type-fest": "^4.20.1",
     "typescript": "^5.0.3"
   }
 }

--- a/packages/cli/display_table/src/components/CompiledQueryDisplay.tsx
+++ b/packages/cli/display_table/src/components/CompiledQueryDisplay.tsx
@@ -4,6 +4,7 @@ import type {
   ResolvedParam,
 } from '@latitude-data/source-manager'
 import { Box, Text } from 'ink'
+import Scrollable from './Scrollable.js'
 
 export default function CompiledQueryDisplay({
   compiledQuery,
@@ -36,9 +37,9 @@ export default function CompiledQueryDisplay({
       borderColor='blue'
       flexWrap='wrap'
     >
-      <Box flexGrow={1} paddingLeft={1}>
+      <Scrollable flexGrow={5} autoFocus>
         <Text>{completeSql()}</Text>
-      </Box>
+      </Scrollable>
       {compiledQuery.resolvedParams.length ? (
         <Box
           flexDirection='column'
@@ -54,16 +55,18 @@ export default function CompiledQueryDisplay({
             {' '}
             Parameterized values{' '}
           </Text>
-          {compiledQuery.resolvedParams.map(
-            (param: ResolvedParam, index: number) => (
-              <Box key={index} flexDirection='row'>
-                <Text color='blue' bold>
-                  {param.resolvedAs}
-                </Text>
-                <Text> {JSON.stringify(param.value)}</Text>
-              </Box>
-            ),
-          )}
+          <Scrollable flexGrow={1} minWidth={32}>
+            {compiledQuery.resolvedParams.map(
+              (param: ResolvedParam, index: number) => (
+                <Box key={index} flexDirection='row'>
+                  <Text color='blue' bold>
+                    {param.resolvedAs}
+                  </Text>
+                  <Text> {JSON.stringify(param.value)}</Text>
+                </Box>
+              ),
+            )}
+          </Scrollable>
         </Box>
       ) : null}
     </Box>

--- a/packages/cli/display_table/src/components/ErrorDisplay.tsx
+++ b/packages/cli/display_table/src/components/ErrorDisplay.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { CompileError } from '@latitude-data/sql-compiler'
 import { Box, Text } from 'ink'
+import Scrollable from './Scrollable'
 
 export default function Error({ error }: { error: Error }) {
   const [errorMsg, setErrorMsg] = useState(error.message)
@@ -24,11 +25,13 @@ export default function Error({ error }: { error: Error }) {
       borderColor='red'
       padding={1}
     >
-      <Text color='red' inverse bold>
-        {' '}
-        {errorType}{' '}
-      </Text>
-      <Text color='red'> {errorMsg} </Text>
+      <Scrollable autoFocus scrollbarColor='red'>
+        <Text color='red' inverse bold>
+          {' '}
+          {errorType}{' '}
+        </Text>
+        <Text color='red'> {errorMsg} </Text>
+      </Scrollable>
     </Box>
   )
 }

--- a/packages/cli/display_table/src/components/Scrollable.tsx
+++ b/packages/cli/display_table/src/components/Scrollable.tsx
@@ -1,0 +1,146 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Box, BoxProps, Text, useFocus, useFocusManager, useInput } from 'ink'
+import type { BackgroundColorName, ForegroundColorName } from 'chalk'
+import type { LiteralUnion } from 'type-fest'
+import useResize from '../hooks/useResize.js'
+
+type Color = LiteralUnion<ForegroundColorName, string>
+type BgColor = LiteralUnion<BackgroundColorName, string>
+
+type Props = BoxProps & {
+  children: React.ReactNode
+  scrollbarActiveChar?: string
+  scrollbarInactiveChar?: string
+  scrollbarColor?: Color
+  scrolltrackColor?: BgColor
+  scrollbarWidth?: number
+  autoFocus?: boolean
+}
+
+export default function Scrollable({
+  children,
+  scrolltrackColor = 'gray',
+  scrollbarColor = 'blue',
+  scrollbarActiveChar = '█',
+  scrollbarInactiveChar = '▓',
+  scrollbarWidth = 1,
+  autoFocus = false,
+  ...rest
+}: Props) {
+  const [viewHeight, setViewHeight] = useState(0)
+  const [viewWidth, setViewWidth] = useState(0)
+  const [contentHeight, setContentHeight] = useState(0)
+  const doesOverflow = useMemo(
+    () => contentHeight > viewHeight,
+    [contentHeight, viewHeight],
+  )
+  const heightRatio = useMemo(() => {
+    if (viewHeight === 0) return 0
+    if (contentHeight < viewHeight) return 1
+    return viewHeight / contentHeight
+  }, [viewHeight, contentHeight])
+
+  const [offset, setOffset] = useState(0)
+
+  const { isFocused } = useFocus({ autoFocus })
+  const { focusNext, focusPrevious } = useFocusManager()
+
+  const [scrollbarHeight, setScrollbarHeight] = useState(0)
+  const [scrollbarOffset, setScrollbarOffset] = useState(0)
+
+  const viewRef = useRef(null)
+  const contentRef = useRef(null)
+  useResize(viewRef, ({ width, height }) => {
+    setViewWidth(width)
+    setViewHeight(height)
+  })
+  useResize(contentRef, ({ height }) => {
+    setContentHeight(height)
+  })
+
+  const scroll = useCallback(
+    (amount: number) => {
+      if (!doesOverflow) return setOffset(0)
+      const newOffset = offset + amount
+      if (newOffset < 0) return setOffset(0)
+      if (newOffset + viewHeight > contentHeight)
+        return setOffset(contentHeight - viewHeight)
+      setOffset(newOffset)
+    },
+    [offset, viewHeight, contentHeight, doesOverflow],
+  )
+
+  useEffect(() => {
+    scroll(0)
+  }, [scroll])
+
+  useInput((input, key) => {
+    if (!isFocused) return
+    if (input === 'j' || key.downArrow) scroll(1)
+    if (input === 'k' || key.upArrow) scroll(-1)
+    if (input === 'h' || key.leftArrow) focusPrevious()
+    if (input === 'l' || key.rightArrow) focusNext()
+  })
+
+  useEffect(() => {
+    setScrollbarHeight(Math.floor(viewHeight * heightRatio))
+  }, [viewHeight, heightRatio])
+
+  useEffect(() => {
+    if (viewHeight + offset >= contentHeight)
+      return setScrollbarOffset(Math.floor(viewHeight - scrollbarHeight))
+    setScrollbarOffset(Math.floor(offset * heightRatio))
+  }, [offset, heightRatio, viewHeight, contentHeight, scrollbarHeight])
+
+  return (
+    <Box position='relative' height='100%' {...rest}>
+      <Box
+        ref={viewRef}
+        height='100%'
+        flexGrow={1}
+        flexDirection='row'
+        overflow='hidden'
+      >
+        <Box
+          ref={contentRef}
+          position='absolute'
+          width={doesOverflow ? viewWidth - scrollbarWidth : viewWidth}
+          flexDirection='column'
+          marginTop={-offset}
+        >
+          {children}
+        </Box>
+        {doesOverflow && (
+          <Box
+            position='absolute'
+            marginLeft={viewWidth - scrollbarWidth}
+            width={scrollbarWidth}
+            height={viewHeight}
+            flexDirection='column'
+          >
+            {Array.from({ length: viewHeight }, (_, index) => {
+              const isScrollbar =
+                index >= scrollbarOffset &&
+                index < scrollbarOffset + scrollbarHeight
+              const scrollbarChar = isScrollbar
+                ? isFocused
+                  ? scrollbarActiveChar
+                  : scrollbarInactiveChar
+                : ' '
+              return (
+                <Text
+                  key={index}
+                  backgroundColor={scrolltrackColor}
+                  color={scrollbarColor}
+                  dimColor={isScrollbar && !isFocused}
+                >
+                  {scrollbarChar.repeat(scrollbarWidth)}
+                </Text>
+              )
+            })}
+          </Box>
+        )}
+      </Box>
+    </Box>
+  )
+}

--- a/packages/cli/display_table/src/components/Table.tsx
+++ b/packages/cli/display_table/src/components/Table.tsx
@@ -147,9 +147,11 @@ export default function Table({ data }: { data: QueryResult }) {
     if (selectedCell.col < colsOffset) {
       setColsOffset(selectedCell.col)
     } else if (selectedCell.col >= colsOffset + visibleCols.length) {
-      setColsOffset(selectedCell.col - visibleCols.length + 1)
+      setColsOffset(
+        Math.min(columns.length - 1, selectedCell.col - visibleCols.length + 1),
+      )
     }
-  }, [selectedCell, visibleRows.length, visibleCols.length])
+  }, [selectedCell, visibleRows.length, visibleCols.length, columns.length])
 
   return (
     <Box

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -360,7 +360,7 @@ importers:
         specifier: ^18.2.74
         version: 18.2.74
       chalk:
-        specifier: ^5.2.0
+        specifier: ^5.3.0
         version: 5.3.0
       eslint-plugin-react:
         specifier: ^7.32.2
@@ -377,6 +377,9 @@ importers:
       ts-node:
         specifier: ^10.9.1
         version: 10.9.2(@types/node@20.12.12)(typescript@5.4.3)
+      type-fest:
+        specifier: ^4.20.1
+        version: 4.20.1
       typescript:
         specifier: ^5.0.3
         version: 5.4.3
@@ -24347,6 +24350,11 @@ packages:
 
   /type-fest@4.15.0:
     resolution: {integrity: sha512-tB9lu0pQpX5KJq54g+oHOLumOx+pMep4RaM6liXh2PKmVRFF+/vAtUP0ZaJ0kOySfVNjF6doBWPHhBhISKdlIA==}
+    engines: {node: '>=16'}
+    dev: true
+
+  /type-fest@4.20.1:
+    resolution: {integrity: sha512-R6wDsVsoS9xYOpy8vgeBlqpdOyzJ12HNfQhC/aAKWM3YoCV9TtunJzh/QpkMgeDhkoynDcw5f1y+qF9yc/HHyg==}
     engines: {node: '>=16'}
     dev: true
 


### PR DESCRIPTION
## Describe your changes
A collection of bugfixes for the table component of the `latitude run` command.

### Table is empty when there's only 1 cell

Before|After
-------|-------
![Before](https://github.com/latitude-dev/latitude/assets/57395395/7f0c7cf9-4508-45a6-9a40-6aaee366daa9) | ![After](https://github.com/latitude-dev/latitude/assets/57395395/0a7de210-fa16-46ee-8992-9f085e384cb3)

### Overflowing text is not visible

Before|After
-------|-------
![Convert to GIF project 2024-06-20](https://github.com/latitude-dev/latitude/assets/57395395/070460cc-39f3-4993-a70d-4ced7c685db8) | ![Convert to GIF project (1)](https://github.com/latitude-dev/latitude/assets/57395395/9fe71690-abdf-426c-a89f-9239ac53d81b)


