### PR TITLE
Version Packages (canary)

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -45,6 +45,7 @@
     "hungry-adults-jump",
     "lovely-apricots-bake",
     "orange-pets-act",
+    "ten-chefs-cheat",
     "ten-masks-tap",
     "tender-years-rhyme",
     "wet-bikes-check",

--- a/packages/cli/core/CHANGELOG.md
+++ b/packages/cli/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @latitude-data/cli
 
+## 1.11.0-canary.4
+
+### Patch Changes
+
+- c2802e4: Some more fixes to make cloud deploy work
+
 ## 1.11.0-canary.3
 
 ### Patch Changes

--- a/packages/cli/core/package.json
+++ b/packages/cli/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@latitude-data/cli",
   "description": "CLI for Latitude",
-  "version": "1.11.0-canary.3",
+  "version": "1.11.0-canary.4",
   "license": "LGPL",
   "bin": {
     "latitude": "dist/cli.js"


### PR DESCRIPTION
## Describe your changes


## CI changes action is broken
Check: `error: pathspec 'changeset-release/canary' did not match any file(s) known to git`
```bash
3s
Run changesets/action@v[1](https://github.com/latitude-dev/latitude/actions/runs/9662036083/job/26651507893#step:5:1)
setting git user
/usr/bin/git config user.name "github-actions[bot]"
/usr/bin/git config user.email "github-actions[bot]@users.noreply.github.com"
setting GitHub credentials
/usr/bin/git checkout changeset-release/canary
error: pathspec 'changeset-release/canary' did not match any file(s) known to git
/usr/bin/git checkout -b changeset-release/canary
Switched to a new branch 'changeset-release/canary'
/usr/bin/git reset --hard c2802e47262022bc497b21a286a6cac4ab912a3c
HEAD is now at c2802e4 Some fixes to make cloud deploy work (#530)
/opt/hostedtoolcache/node/[18](https://github.com/latitude-dev/latitude/actions/runs/9662036083/job/26651507893#step:5:19).20.3/x64/bin/node /home/runner/work/latitude/latitude/node_modules/.pnpm/@changesets+cli@2.27.1/node_modules/@changesets/cli/bin.js version
🦋  warn ===============================IMPORTANT!===============================
🦋  warn You are in prerelease mode
🦋  warn If you meant to do a normal release you should revert these changes and run `changeset pre exit`
🦋  warn You can then run `changeset version` again to do a normal release
🦋  warn ----------------------------------------------------------------------
🦋  All files have been updated. Review them and commit at your leisure
/usr/bin/git status --porcelain
 M .changeset/pre.json
 M packages/cli/core/CHANGELOG.md
 M packages/cli/core/package.json
/usr/bin/git add .
/usr/bin/git commit -m Version Packages (canary)
[changeset-release/canary 6e9acad] Version Packages (canary)
 3 files changed, 8 insertions(+), 1 deletion(-)
/usr/bin/git push origin HEAD:changeset-release/canary --force
/home/runner/work/_actions/changesets/action/v1/dist/index.js:1
```

