### PR TITLE
Fix cli version checking

### DIFF
--- a/packages/cli/core/src/commands/version/index.ts
+++ b/packages/cli/core/src/commands/version/index.ts
@@ -11,7 +11,7 @@ function versionLine({ name, version }: { name: string; version: string }) {
 async function showVersions() {
   const latitudeJson = await findOrCreateConfigFile()
   const appVersion = latitudeJson.data.version
-  const installed = getInstalledVersion(config.rootDir)
+  const installed = getInstalledVersion(config.appDir)
   boxedMessage({
     color: 'green',
     title: 'Latitude versions',

--- a/packages/cli/core/src/lib/setupApp/cloneAppFromNpm.ts
+++ b/packages/cli/core/src/lib/setupApp/cloneAppFromNpm.ts
@@ -18,7 +18,7 @@ export default async function cloneAppFromNpm({
   const latitudeJson = await findOrCreateConfigFile()
   version = version ?? latitudeJson.data.version
   const command = `npm view ${PACKAGE_NAME}@${version} dist.tarball`
-  const installedVersion = getInstalledVersion(config.rootDir)
+  const installedVersion = getInstalledVersion(config.appDir)
 
   if (installedVersion === version && existsSync(config.appDir)) return
 


### PR DESCRIPTION
## Describe your changes

CLI is not detecting the installed version correctly. This makes the CLI always update to the latest version. The problem is that we're reading the version from the Latitude Project's root package.json, instead of the `.latitude/app` package.json