### PR TITLE
Fix build when prompts folder does not exists

### DIFF
--- a/.changeset/wicked-dolphins-raise.md
+++ b/.changeset/wicked-dolphins-raise.md
@@ -1,0 +1,5 @@
+---
+"@latitude-data/cli": patch
+---
+
+Fix build failing when projects does not has a prompts folder

--- a/packages/cli/core/src/lib/sync/syncPrompts/index.test.ts
+++ b/packages/cli/core/src/lib/sync/syncPrompts/index.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it, vi } from 'vitest'
+import { syncDirectory } from './index'
+
+describe('syncDirectory', () => {
+  it('does not fail when does not exists', () => {
+    const syncFn = vi.fn()
+    const folder = '/prompts/somthing.prompt'
+
+    syncDirectory(folder, syncFn)
+
+    expect(syncFn).not.toHaveBeenCalled()
+  })
+})

--- a/packages/cli/core/src/lib/sync/syncPrompts/index.ts
+++ b/packages/cli/core/src/lib/sync/syncPrompts/index.ts
@@ -37,6 +37,8 @@ function buildDestPath({
 }
 
 export function syncDirectory(dirPath: string, syncFn: Function): void {
+  if (!existsSync(dirPath)) return
+
   readdirSync(dirPath, { withFileTypes: true }).forEach((dirent) => {
     const currentPath = path.join(dirPath, dirent.name)
     if (dirent.isDirectory()) {


### PR DESCRIPTION
## Describe your changes
Fix this issue:
https://latitude-l5.sentry.io/issues/5542712717/?alert_rule_id=15084066&alert_type=issue&environment=production&notification_uuid=aa57f84a-01a5-4227-ae23-1b5679f76654&project=4506981816401920&referrer=slack

