### PR TITLE
Do not cut off last athena ResultSet row

### DIFF
--- a/packages/connectors/athena/src/index.ts
+++ b/packages/connectors/athena/src/index.ts
@@ -130,7 +130,9 @@ export default class AthenaConnector extends BaseConnector<ConnectionParams> {
         )
 
         const rowCount = ResultSet?.Rows?.length
-        const rows = ResultSet?.Rows?.slice(1, -1).map(
+          ? ResultSet.Rows.length - 1
+          : undefined
+        const rows = ResultSet?.Rows?.slice(1).map(
           (row: Row) => row?.Data?.map((value) => value.VarCharValue) || [],
         )
         const fields = ResultSet?.ResultSetMetadata?.ColumnInfo?.map(


### PR DESCRIPTION
## Describe your changes

Fixed a bug that was cutting off of the last row of Athena results and corrected the row count for these results. 

## Issue ticket number and link
#553 

## Checklist before requesting a review
- [ ] I have added thorough tests
- [x] I have updated the documentation if necessary
- [x] I have added a human-readable description of the changes for the release notes
- [x] I have included a recorded video capture of the feature manually tested


https://github.com/user-attachments/assets/b66d1ddd-e56b-4b7b-961d-c9aab27f9ab0

